### PR TITLE
Add additional filters

### DIFF
--- a/PRChecker/Shared/Extensions/Array+Extensions.swift
+++ b/PRChecker/Shared/Extensions/Array+Extensions.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension Array where Element: Equatable {
-    func removingLaterDuplicates() -> [Element] {
+    func arrayByRemovingDuplicates() -> [Element] {
         var resultArray = [Element]()
         self.forEach { element in
             guard !resultArray.contains(element) else { return }

--- a/PRChecker/Shared/Unique Views/PRListView.swift
+++ b/PRChecker/Shared/Unique Views/PRListView.swift
@@ -23,20 +23,9 @@ struct PRListView: View {
         }) {
             LazyVGrid(columns: [GridItem(.adaptive(minimum: 300))], alignment: .leading, pinnedViews: [.sectionHeaders]) {
                 
-                Section(header: Rectangle().frame(height: 45).foregroundColor(.gray5).overlay(Text("You").font(.title).bold().padding(.leading), alignment: .leading)) {
-                    ForEach(prListViewModel.prList.filter(filterViewModel.combinedFilter?.filter ?? { _ in true }), id: \.id) { pullRequest in
-                        PullRequestCell(pullRequest: pullRequest)
-                            .cornerRadius(16)
-                            .overlay(RoundedRectangle(cornerRadius: 16).stroke(Color.gray3, lineWidth: 1))
-                            .onTapGesture {
-                                openURL(URL(string: pullRequest.url)!)
-                            }
-                    }
-                }
-                
-                ForEach(watchedUserViewModel.prList, id: \.0) { (name, prList) in
-                    Section(header: Rectangle().frame(height: 45).foregroundColor(.gray5).overlay(Text(name).font(.title).bold().padding(.leading), alignment: .leading)) {
-                        ForEach(prList.filter(filterViewModel.combinedFilter?.filter ?? { _ in true }), id: \.id) { pullRequest in
+                if let filteredPRList = prListViewModel.prList.filter(filterViewModel.combinedFilter?.filter ?? { _ in true }), !filteredPRList.isEmpty {
+                    Section(header: Rectangle().frame(height: 45).foregroundColor(.gray5).overlay(Text("You").font(.title).bold().padding(.leading), alignment: .leading)) {
+                        ForEach(filteredPRList, id: \.id) { pullRequest in
                             PullRequestCell(pullRequest: pullRequest)
                                 .cornerRadius(16)
                                 .overlay(RoundedRectangle(cornerRadius: 16).stroke(Color.gray3, lineWidth: 1))
@@ -48,22 +37,42 @@ struct PRListView: View {
                 }
                 
                 
-    
+                ForEach(watchedUserViewModel.prList, id: \.0) { (name, prList) in
+                    if let filteredPRList = prList.filter(filterViewModel.combinedFilter?.filter ?? { _ in true }), !filteredPRList.isEmpty {
+                        
+                        Section(header: Rectangle().frame(height: 45).foregroundColor(.gray5).overlay(Text(name).font(.title).bold().padding(.leading), alignment: .leading)) {
+                            ForEach(filteredPRList, id: \.id) { pullRequest in
+                                PullRequestCell(pullRequest: pullRequest)
+                                    .cornerRadius(16)
+                                    .overlay(RoundedRectangle(cornerRadius: 16).stroke(Color.gray3, lineWidth: 1))
+                                    .onTapGesture {
+                                        openURL(URL(string: pullRequest.url)!)
+                                    }
+                            }
+                        }
+                    }
+                    
+                }
             }
             .padding()
             .onAppear {
                 prListViewModel.getPRList()
                 watchedUserViewModel.getPRList()
             }
-            .onChange(of: prListViewModel.additionalFilters) { newValue in
-                if let labelSection = filterViewModel.sections.first(where: { $0.name == "Labels" }) {
-                    labelSection.filters = newValue?["Labels"] ?? []
-                }
-                
-                if let repositorySection = filterViewModel.sections.first(where: { $0.name == "Repository" }) {
-                    repositorySection.filters = newValue?["Repository"] ?? []
-                }
-            }
+            .onChange(of: prListViewModel.additionalFilters, perform: updateAdditionalFilters(_:))
+            .onChange(of: watchedUserViewModel.additionalFilters, perform: updateAdditionalFilters(_:))
+        }
+    }
+    
+    private func updateAdditionalFilters(_ filters: [String: [Filter]]?) {
+        if let labelSection = filterViewModel.sections.first(where: { $0.name == "Labels" }) {
+            let combinedFilters = labelSection.filters + (filters?["Labels"] ?? [])
+            labelSection.filters = combinedFilters.arrayByRemovingDuplicates().sorted { $0.name < $1.name }
+        }
+        
+        if let repositorySection = filterViewModel.sections.first(where: { $0.name == "Repository" }) {
+            let combinedFilters = repositorySection.filters + (filters?["Repository"] ?? [])
+            repositorySection.filters = combinedFilters.arrayByRemovingDuplicates().sorted { $0.name < $1.name }
         }
     }
 }

--- a/PRChecker/Shared/ViewModels/PRListViewModel.swift
+++ b/PRChecker/Shared/ViewModels/PRListViewModel.swift
@@ -30,12 +30,12 @@ class PRListViewModel: ObservableObject {
                             }
                         }
                     }
-                        .removingLaterDuplicates()
+                        .arrayByRemovingDuplicates()
                     
                     let repositoryFilters = self.prList.map(\.repositoryName).map { name in
                         Filter(name: name) { $0.repositoryName == name }
                     }
-                        .removingLaterDuplicates()
+                        .arrayByRemovingDuplicates()
                     
                     self.additionalFilters = [
                         "Labels": labelFilters,

--- a/PRChecker/Shared/ViewModels/SettingsViewModel.swift
+++ b/PRChecker/Shared/ViewModels/SettingsViewModel.swift
@@ -22,7 +22,7 @@ struct SettingsViewModel {
     
     mutating func addUser() {
         guard !newUsername.isEmpty else { return }
-        userList = ([newUsername.lowercased()] + userList).removingLaterDuplicates().sorted(by: <)
+        userList = ([newUsername.lowercased()] + userList).arrayByRemovingDuplicates().sorted(by: <)
         newUsername = ""
         UserDefaults.standard.set(userList, forKey: UserDefaultsKey.userList)
     }

--- a/PRChecker/Shared/ViewModels/WatchedUserViewModel.swift
+++ b/PRChecker/Shared/ViewModels/WatchedUserViewModel.swift
@@ -10,6 +10,7 @@ import Foundation
 
 class WatchedUserViewModel: ObservableObject {
     @Published var prList = [(String, [PullRequest])]()
+    @Published var additionalFilters: [String: [Filter]]?
     
     private var subscriptions = Set<AnyCancellable>()
     private var userList: [String]
@@ -24,7 +25,26 @@ class WatchedUserViewModel: ObservableObject {
                 // TODO: Handle Error
             } receiveValue: { newEntry in
                 DispatchQueue.main.async {
-                    self.prList.append(newEntry)
+                    self.prList = (self.prList + [newEntry]).sorted { $0.0 < $1.0 }
+                    
+                    let labelFilters = self.prList.map(\.1).flatMap { $0 }.map(\.labels).flatMap { $0 }.map { label in
+                        Filter(name: label.title) { pullRequest in
+                            pullRequest.labels.contains { prLabel in
+                                prLabel == label
+                            }
+                        }
+                    }
+                        .arrayByRemovingDuplicates()
+                    
+                    let repositoryFilters = self.prList.map(\.1).flatMap { $0 }.map(\.repositoryName).map { name in
+                        Filter(name: name) { $0.repositoryName == name }
+                    }
+                        .arrayByRemovingDuplicates()
+                    
+                    self.additionalFilters = [
+                        "Labels": labelFilters,
+                        "Repository": repositoryFilters,
+                    ]
                 }
             }
             .store(in: &subscriptions)


### PR DESCRIPTION
Currently labels and repo names only get added to the filters if the main user list includes them. This expands on that and allows "watched" users to contribute to the filters.

As a bonus, if the list is empty (due to a filter or not) that username will no longer be shown as an empty section.