### PR TITLE
Enable usage on Github Enterprise 2.20

### DIFF
--- a/PRChecker/PRChecker.xcodeproj/project.pbxproj
+++ b/PRChecker/PRChecker.xcodeproj/project.pbxproj
@@ -33,6 +33,10 @@
 		692A74E9273204F200C872AB /* ApolloSQLite in Frameworks */ = {isa = PBXBuildFile; productRef = 692A74E8273204F200C872AB /* ApolloSQLite */; };
 		692A74EB273204F200C872AB /* ApolloUtils in Frameworks */ = {isa = PBXBuildFile; productRef = 692A74EA273204F200C872AB /* ApolloUtils */; };
 		692A74ED273204F200C872AB /* ApolloWebSocket in Frameworks */ = {isa = PBXBuildFile; productRef = 692A74EC273204F200C872AB /* ApolloWebSocket */; };
+		6961B760273A8E9400A238F4 /* OldPullRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6961B75F273A8E9400A238F4 /* OldPullRequest.swift */; };
+		6961B761273A8E9400A238F4 /* OldPullRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6961B75F273A8E9400A238F4 /* OldPullRequest.swift */; };
+		6961B763273A8EA900A238F4 /* AbstractPullRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6961B762273A8EA900A238F4 /* AbstractPullRequest.swift */; };
+		6961B764273A8EA900A238F4 /* AbstractPullRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6961B762273A8EA900A238F4 /* AbstractPullRequest.swift */; };
 		69BB4C1B27357FD4001175C8 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69BB4C1A27357FD4001175C8 /* LoginView.swift */; };
 		69BB4C1C27357FD4001175C8 /* LoginView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69BB4C1A27357FD4001175C8 /* LoginView.swift */; };
 		69BB4C272736CB60001175C8 /* PRListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69BB4C262736CB60001175C8 /* PRListView.swift */; };
@@ -87,6 +91,8 @@
 		59CEC3D5273803BB003F94B1 /* PRItemLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PRItemLabel.swift; sourceTree = "<group>"; };
 		59DDC04E2737714200101394 /* PRItemType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PRItemType.swift; sourceTree = "<group>"; };
 		59DDC0512737ABAE00101394 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		6961B75F273A8E9400A238F4 /* OldPullRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OldPullRequest.swift; sourceTree = "<group>"; };
+		6961B762273A8EA900A238F4 /* AbstractPullRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbstractPullRequest.swift; sourceTree = "<group>"; };
 		69BB4C1A27357FD4001175C8 /* LoginView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginView.swift; sourceTree = "<group>"; };
 		69BB4C262736CB60001175C8 /* PRListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PRListView.swift; sourceTree = "<group>"; };
 		69BB4C292736CB64001175C8 /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
@@ -267,7 +273,9 @@
 		69D6438F27325F660001BBBA /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				6961B762273A8EA900A238F4 /* AbstractPullRequest.swift */,
 				69D6439027325F6F0001BBBA /* PullRequest.swift */,
+				6961B75F273A8E9400A238F4 /* OldPullRequest.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -443,6 +451,7 @@
 				69BB4C312736EC24001175C8 /* FilterViewModel.swift in Sources */,
 				69CA34A2273161C0004D5D9C /* ContentView.swift in Sources */,
 				69BB4C2A2736CB64001175C8 /* Constants.swift in Sources */,
+				6961B760273A8E9400A238F4 /* OldPullRequest.swift in Sources */,
 				69CA34C5273165D3004D5D9C /* API.swift in Sources */,
 				59CEC3D3273801FA003F94B1 /* Tag.swift in Sources */,
 				69BB4C3A27379B46001175C8 /* Array+Extensions.swift in Sources */,
@@ -454,6 +463,7 @@
 				5931189A2736758400BA67BC /* FilterView.swift in Sources */,
 				69D6438A2732573A0001BBBA /* LoginInfoViewModel.swift in Sources */,
 				69BB4C4C2737EEB4001175C8 /* SettingsView.swift in Sources */,
+				6961B763273A8EA900A238F4 /* AbstractPullRequest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -475,6 +485,7 @@
 				69BB4C1C27357FD4001175C8 /* LoginView.swift in Sources */,
 				69BB4C322736EC24001175C8 /* FilterViewModel.swift in Sources */,
 				69CA34A3273161C0004D5D9C /* ContentView.swift in Sources */,
+				6961B764273A8EA900A238F4 /* AbstractPullRequest.swift in Sources */,
 				69BB4C2B2736CB64001175C8 /* Constants.swift in Sources */,
 				69CA34C6273165D3004D5D9C /* API.swift in Sources */,
 				59CEC3D4273801FA003F94B1 /* Tag.swift in Sources */,
@@ -486,6 +497,7 @@
 				69CA34A1273161C0004D5D9C /* PRCheckerApp.swift in Sources */,
 				5990F52D27396BB1007DC686 /* MyPRManager.swift in Sources */,
 				59CEC3D7273803BB003F94B1 /* PRItemLabel.swift in Sources */,
+				6961B761273A8E9400A238F4 /* OldPullRequest.swift in Sources */,
 				5931189B2736758400BA67BC /* FilterView.swift in Sources */,
 				69D6438B2732573A0001BBBA /* LoginInfoViewModel.swift in Sources */,
 				69BB4C502737F1B1001175C8 /* SettingsViewModel.swift in Sources */,

--- a/PRChecker/Shared/Constants.swift
+++ b/PRChecker/Shared/Constants.swift
@@ -12,6 +12,7 @@ enum KeychainKey {
     static let apiEndpoint = "API_ENDPOINT_URL"
     static let username = "USERNAME"
     static let accessToken = "ACCESST_TOKEN"
+    static let legacyQueryFlag = "LEGACY_QUERY_FLAG"
 }
 
 enum UserDefaultsKey {

--- a/PRChecker/Shared/Constants.swift
+++ b/PRChecker/Shared/Constants.swift
@@ -12,9 +12,9 @@ enum KeychainKey {
     static let apiEndpoint = "API_ENDPOINT_URL"
     static let username = "USERNAME"
     static let accessToken = "ACCESST_TOKEN"
-    static let legacyQueryFlag = "LEGACY_QUERY_FLAG"
 }
 
 enum UserDefaultsKey {
     static let userList = "io.brevans.PPRChecker.userList"
+    static let legacyQueries = "io.brevans.PRChecker.legacyQueries"
 }

--- a/PRChecker/Shared/General/MyPRManager.swift
+++ b/PRChecker/Shared/General/MyPRManager.swift
@@ -11,7 +11,7 @@ class MyPRManager: ObservableObject {
 
     static var shared = MyPRManager()
 
-    @Published var prList: [PullRequest] = []
+    @Published var prList: [AbstractPullRequest] = []
 
     private init() {}
 }

--- a/PRChecker/Shared/GraphQL/API.swift
+++ b/PRChecker/Shared/GraphQL/API.swift
@@ -610,6 +610,276 @@ public final class GetAssignedPRsWithQueryQuery: GraphQLQuery {
   }
 }
 
+public final class GetOldAssignedPRsWithQueryQuery: GraphQLQuery {
+  /// The raw GraphQL definition of this operation.
+  public let operationDefinition: String =
+    """
+    query GetOldAssignedPRsWithQuery($query: String!) {
+      search(last: 100, query: $query, type: ISSUE) {
+        __typename
+        edges {
+          __typename
+          node {
+            __typename
+            ... on PullRequest {
+              ...OldPRInfo
+            }
+          }
+        }
+      }
+    }
+    """
+
+  public let operationName: String = "GetOldAssignedPRsWithQuery"
+
+  public var queryDocument: String {
+    var document: String = operationDefinition
+    document.append("\n" + OldPrInfo.fragmentDefinition)
+    return document
+  }
+
+  public var query: String
+
+  public init(query: String) {
+    self.query = query
+  }
+
+  public var variables: GraphQLMap? {
+    return ["query": query]
+  }
+
+  public struct Data: GraphQLSelectionSet {
+    public static let possibleTypes: [String] = ["Query"]
+
+    public static var selections: [GraphQLSelection] {
+      return [
+        GraphQLField("search", arguments: ["last": 100, "query": GraphQLVariable("query"), "type": "ISSUE"], type: .nonNull(.object(Search.selections))),
+      ]
+    }
+
+    public private(set) var resultMap: ResultMap
+
+    public init(unsafeResultMap: ResultMap) {
+      self.resultMap = unsafeResultMap
+    }
+
+    public init(search: Search) {
+      self.init(unsafeResultMap: ["__typename": "Query", "search": search.resultMap])
+    }
+
+    /// Perform a search across resources.
+    public var search: Search {
+      get {
+        return Search(unsafeResultMap: resultMap["search"]! as! ResultMap)
+      }
+      set {
+        resultMap.updateValue(newValue.resultMap, forKey: "search")
+      }
+    }
+
+    public struct Search: GraphQLSelectionSet {
+      public static let possibleTypes: [String] = ["SearchResultItemConnection"]
+
+      public static var selections: [GraphQLSelection] {
+        return [
+          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+          GraphQLField("edges", type: .list(.object(Edge.selections))),
+        ]
+      }
+
+      public private(set) var resultMap: ResultMap
+
+      public init(unsafeResultMap: ResultMap) {
+        self.resultMap = unsafeResultMap
+      }
+
+      public init(edges: [Edge?]? = nil) {
+        self.init(unsafeResultMap: ["__typename": "SearchResultItemConnection", "edges": edges.flatMap { (value: [Edge?]) -> [ResultMap?] in value.map { (value: Edge?) -> ResultMap? in value.flatMap { (value: Edge) -> ResultMap in value.resultMap } } }])
+      }
+
+      public var __typename: String {
+        get {
+          return resultMap["__typename"]! as! String
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "__typename")
+        }
+      }
+
+      /// A list of edges.
+      public var edges: [Edge?]? {
+        get {
+          return (resultMap["edges"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [Edge?] in value.map { (value: ResultMap?) -> Edge? in value.flatMap { (value: ResultMap) -> Edge in Edge(unsafeResultMap: value) } } }
+        }
+        set {
+          resultMap.updateValue(newValue.flatMap { (value: [Edge?]) -> [ResultMap?] in value.map { (value: Edge?) -> ResultMap? in value.flatMap { (value: Edge) -> ResultMap in value.resultMap } } }, forKey: "edges")
+        }
+      }
+
+      public struct Edge: GraphQLSelectionSet {
+        public static let possibleTypes: [String] = ["SearchResultItemEdge"]
+
+        public static var selections: [GraphQLSelection] {
+          return [
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+            GraphQLField("node", type: .object(Node.selections)),
+          ]
+        }
+
+        public private(set) var resultMap: ResultMap
+
+        public init(unsafeResultMap: ResultMap) {
+          self.resultMap = unsafeResultMap
+        }
+
+        public init(node: Node? = nil) {
+          self.init(unsafeResultMap: ["__typename": "SearchResultItemEdge", "node": node.flatMap { (value: Node) -> ResultMap in value.resultMap }])
+        }
+
+        public var __typename: String {
+          get {
+            return resultMap["__typename"]! as! String
+          }
+          set {
+            resultMap.updateValue(newValue, forKey: "__typename")
+          }
+        }
+
+        /// The item at the end of the edge.
+        public var node: Node? {
+          get {
+            return (resultMap["node"] as? ResultMap).flatMap { Node(unsafeResultMap: $0) }
+          }
+          set {
+            resultMap.updateValue(newValue?.resultMap, forKey: "node")
+          }
+        }
+
+        public struct Node: GraphQLSelectionSet {
+          public static let possibleTypes: [String] = ["App", "Discussion", "Issue", "MarketplaceListing", "Organization", "PullRequest", "Repository", "User"]
+
+          public static var selections: [GraphQLSelection] {
+            return [
+              GraphQLTypeCase(
+                variants: ["PullRequest": AsPullRequest.selections],
+                default: [
+                  GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                ]
+              )
+            ]
+          }
+
+          public private(set) var resultMap: ResultMap
+
+          public init(unsafeResultMap: ResultMap) {
+            self.resultMap = unsafeResultMap
+          }
+
+          public static func makeApp() -> Node {
+            return Node(unsafeResultMap: ["__typename": "App"])
+          }
+
+          public static func makeDiscussion() -> Node {
+            return Node(unsafeResultMap: ["__typename": "Discussion"])
+          }
+
+          public static func makeIssue() -> Node {
+            return Node(unsafeResultMap: ["__typename": "Issue"])
+          }
+
+          public static func makeMarketplaceListing() -> Node {
+            return Node(unsafeResultMap: ["__typename": "MarketplaceListing"])
+          }
+
+          public static func makeOrganization() -> Node {
+            return Node(unsafeResultMap: ["__typename": "Organization"])
+          }
+
+          public static func makeRepository() -> Node {
+            return Node(unsafeResultMap: ["__typename": "Repository"])
+          }
+
+          public static func makeUser() -> Node {
+            return Node(unsafeResultMap: ["__typename": "User"])
+          }
+
+          public var __typename: String {
+            get {
+              return resultMap["__typename"]! as! String
+            }
+            set {
+              resultMap.updateValue(newValue, forKey: "__typename")
+            }
+          }
+
+          public var asPullRequest: AsPullRequest? {
+            get {
+              if !AsPullRequest.possibleTypes.contains(__typename) { return nil }
+              return AsPullRequest(unsafeResultMap: resultMap)
+            }
+            set {
+              guard let newValue = newValue else { return }
+              resultMap = newValue.resultMap
+            }
+          }
+
+          public struct AsPullRequest: GraphQLSelectionSet {
+            public static let possibleTypes: [String] = ["PullRequest"]
+
+            public static var selections: [GraphQLSelection] {
+              return [
+                GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+                GraphQLFragmentSpread(OldPrInfo.self),
+              ]
+            }
+
+            public private(set) var resultMap: ResultMap
+
+            public init(unsafeResultMap: ResultMap) {
+              self.resultMap = unsafeResultMap
+            }
+
+            public var __typename: String {
+              get {
+                return resultMap["__typename"]! as! String
+              }
+              set {
+                resultMap.updateValue(newValue, forKey: "__typename")
+              }
+            }
+
+            public var fragments: Fragments {
+              get {
+                return Fragments(unsafeResultMap: resultMap)
+              }
+              set {
+                resultMap += newValue.resultMap
+              }
+            }
+
+            public struct Fragments {
+              public private(set) var resultMap: ResultMap
+
+              public init(unsafeResultMap: ResultMap) {
+                self.resultMap = unsafeResultMap
+              }
+
+              public var oldPrInfo: OldPrInfo {
+                get {
+                  return OldPrInfo(unsafeResultMap: resultMap)
+                }
+                set {
+                  resultMap += newValue.resultMap
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 public struct PrInfo: GraphQLFragment {
   /// The raw GraphQL definition of this fragment.
   public static let fragmentDefinition: String =
@@ -1218,6 +1488,710 @@ public struct PrInfo: GraphQLFragment {
       }
       set {
         resultMap.updateValue(newValue, forKey: "state")
+      }
+    }
+  }
+}
+
+public struct OldPrInfo: GraphQLFragment {
+  /// The raw GraphQL definition of this fragment.
+  public static let fragmentDefinition: String =
+    """
+    fragment OldPRInfo on PullRequest {
+      __typename
+      id
+      url
+      repository {
+        __typename
+        id
+        nameWithOwner
+      }
+      baseRefName
+      headRefName
+      author {
+        __typename
+        login
+      }
+      title
+      body
+      changedFiles
+      additions
+      deletions
+      commits(last: 100) {
+        __typename
+        nodes {
+          __typename
+          id
+        }
+      }
+      labels(last: 10) {
+        __typename
+        nodes {
+          __typename
+          id
+          name
+          color
+        }
+      }
+      state
+      reviews(last: 100) {
+        __typename
+        nodes {
+          __typename
+          author {
+            __typename
+            login
+          }
+          state
+        }
+      }
+      mergedAt
+      updatedAt
+    }
+    """
+
+  public static let possibleTypes: [String] = ["PullRequest"]
+
+  public static var selections: [GraphQLSelection] {
+    return [
+      GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+      GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
+      GraphQLField("url", type: .nonNull(.scalar(String.self))),
+      GraphQLField("repository", type: .nonNull(.object(Repository.selections))),
+      GraphQLField("baseRefName", type: .nonNull(.scalar(String.self))),
+      GraphQLField("headRefName", type: .nonNull(.scalar(String.self))),
+      GraphQLField("author", type: .object(Author.selections)),
+      GraphQLField("title", type: .nonNull(.scalar(String.self))),
+      GraphQLField("body", type: .nonNull(.scalar(String.self))),
+      GraphQLField("changedFiles", type: .nonNull(.scalar(Int.self))),
+      GraphQLField("additions", type: .nonNull(.scalar(Int.self))),
+      GraphQLField("deletions", type: .nonNull(.scalar(Int.self))),
+      GraphQLField("commits", arguments: ["last": 100], type: .nonNull(.object(Commit.selections))),
+      GraphQLField("labels", arguments: ["last": 10], type: .object(Label.selections)),
+      GraphQLField("state", type: .nonNull(.scalar(PullRequestState.self))),
+      GraphQLField("reviews", arguments: ["last": 100], type: .object(Review.selections)),
+      GraphQLField("mergedAt", type: .scalar(String.self)),
+      GraphQLField("updatedAt", type: .nonNull(.scalar(String.self))),
+    ]
+  }
+
+  public private(set) var resultMap: ResultMap
+
+  public init(unsafeResultMap: ResultMap) {
+    self.resultMap = unsafeResultMap
+  }
+
+  public init(id: GraphQLID, url: String, repository: Repository, baseRefName: String, headRefName: String, author: Author? = nil, title: String, body: String, changedFiles: Int, additions: Int, deletions: Int, commits: Commit, labels: Label? = nil, state: PullRequestState, reviews: Review? = nil, mergedAt: String? = nil, updatedAt: String) {
+    self.init(unsafeResultMap: ["__typename": "PullRequest", "id": id, "url": url, "repository": repository.resultMap, "baseRefName": baseRefName, "headRefName": headRefName, "author": author.flatMap { (value: Author) -> ResultMap in value.resultMap }, "title": title, "body": body, "changedFiles": changedFiles, "additions": additions, "deletions": deletions, "commits": commits.resultMap, "labels": labels.flatMap { (value: Label) -> ResultMap in value.resultMap }, "state": state, "reviews": reviews.flatMap { (value: Review) -> ResultMap in value.resultMap }, "mergedAt": mergedAt, "updatedAt": updatedAt])
+  }
+
+  public var __typename: String {
+    get {
+      return resultMap["__typename"]! as! String
+    }
+    set {
+      resultMap.updateValue(newValue, forKey: "__typename")
+    }
+  }
+
+  public var id: GraphQLID {
+    get {
+      return resultMap["id"]! as! GraphQLID
+    }
+    set {
+      resultMap.updateValue(newValue, forKey: "id")
+    }
+  }
+
+  /// The HTTP URL for this pull request.
+  public var url: String {
+    get {
+      return resultMap["url"]! as! String
+    }
+    set {
+      resultMap.updateValue(newValue, forKey: "url")
+    }
+  }
+
+  /// The repository associated with this node.
+  public var repository: Repository {
+    get {
+      return Repository(unsafeResultMap: resultMap["repository"]! as! ResultMap)
+    }
+    set {
+      resultMap.updateValue(newValue.resultMap, forKey: "repository")
+    }
+  }
+
+  /// Identifies the name of the base Ref associated with the pull request, even if the ref has been deleted.
+  public var baseRefName: String {
+    get {
+      return resultMap["baseRefName"]! as! String
+    }
+    set {
+      resultMap.updateValue(newValue, forKey: "baseRefName")
+    }
+  }
+
+  /// Identifies the name of the head Ref associated with the pull request, even if the ref has been deleted.
+  public var headRefName: String {
+    get {
+      return resultMap["headRefName"]! as! String
+    }
+    set {
+      resultMap.updateValue(newValue, forKey: "headRefName")
+    }
+  }
+
+  /// The actor who authored the comment.
+  public var author: Author? {
+    get {
+      return (resultMap["author"] as? ResultMap).flatMap { Author(unsafeResultMap: $0) }
+    }
+    set {
+      resultMap.updateValue(newValue?.resultMap, forKey: "author")
+    }
+  }
+
+  /// Identifies the pull request title.
+  public var title: String {
+    get {
+      return resultMap["title"]! as! String
+    }
+    set {
+      resultMap.updateValue(newValue, forKey: "title")
+    }
+  }
+
+  /// The body as Markdown.
+  public var body: String {
+    get {
+      return resultMap["body"]! as! String
+    }
+    set {
+      resultMap.updateValue(newValue, forKey: "body")
+    }
+  }
+
+  /// The number of changed files in this pull request.
+  public var changedFiles: Int {
+    get {
+      return resultMap["changedFiles"]! as! Int
+    }
+    set {
+      resultMap.updateValue(newValue, forKey: "changedFiles")
+    }
+  }
+
+  /// The number of additions in this pull request.
+  public var additions: Int {
+    get {
+      return resultMap["additions"]! as! Int
+    }
+    set {
+      resultMap.updateValue(newValue, forKey: "additions")
+    }
+  }
+
+  /// The number of deletions in this pull request.
+  public var deletions: Int {
+    get {
+      return resultMap["deletions"]! as! Int
+    }
+    set {
+      resultMap.updateValue(newValue, forKey: "deletions")
+    }
+  }
+
+  /// A list of commits present in this pull request's head branch not present in the base branch.
+  public var commits: Commit {
+    get {
+      return Commit(unsafeResultMap: resultMap["commits"]! as! ResultMap)
+    }
+    set {
+      resultMap.updateValue(newValue.resultMap, forKey: "commits")
+    }
+  }
+
+  /// A list of labels associated with the object.
+  public var labels: Label? {
+    get {
+      return (resultMap["labels"] as? ResultMap).flatMap { Label(unsafeResultMap: $0) }
+    }
+    set {
+      resultMap.updateValue(newValue?.resultMap, forKey: "labels")
+    }
+  }
+
+  /// Identifies the state of the pull request.
+  public var state: PullRequestState {
+    get {
+      return resultMap["state"]! as! PullRequestState
+    }
+    set {
+      resultMap.updateValue(newValue, forKey: "state")
+    }
+  }
+
+  /// A list of reviews associated with the pull request.
+  public var reviews: Review? {
+    get {
+      return (resultMap["reviews"] as? ResultMap).flatMap { Review(unsafeResultMap: $0) }
+    }
+    set {
+      resultMap.updateValue(newValue?.resultMap, forKey: "reviews")
+    }
+  }
+
+  /// The date and time that the pull request was merged.
+  public var mergedAt: String? {
+    get {
+      return resultMap["mergedAt"] as? String
+    }
+    set {
+      resultMap.updateValue(newValue, forKey: "mergedAt")
+    }
+  }
+
+  /// Identifies the date and time when the object was last updated.
+  public var updatedAt: String {
+    get {
+      return resultMap["updatedAt"]! as! String
+    }
+    set {
+      resultMap.updateValue(newValue, forKey: "updatedAt")
+    }
+  }
+
+  public struct Repository: GraphQLSelectionSet {
+    public static let possibleTypes: [String] = ["Repository"]
+
+    public static var selections: [GraphQLSelection] {
+      return [
+        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+        GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
+        GraphQLField("nameWithOwner", type: .nonNull(.scalar(String.self))),
+      ]
+    }
+
+    public private(set) var resultMap: ResultMap
+
+    public init(unsafeResultMap: ResultMap) {
+      self.resultMap = unsafeResultMap
+    }
+
+    public init(id: GraphQLID, nameWithOwner: String) {
+      self.init(unsafeResultMap: ["__typename": "Repository", "id": id, "nameWithOwner": nameWithOwner])
+    }
+
+    public var __typename: String {
+      get {
+        return resultMap["__typename"]! as! String
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "__typename")
+      }
+    }
+
+    public var id: GraphQLID {
+      get {
+        return resultMap["id"]! as! GraphQLID
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "id")
+      }
+    }
+
+    /// The repository's name with owner.
+    public var nameWithOwner: String {
+      get {
+        return resultMap["nameWithOwner"]! as! String
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "nameWithOwner")
+      }
+    }
+  }
+
+  public struct Author: GraphQLSelectionSet {
+    public static let possibleTypes: [String] = ["Bot", "EnterpriseUserAccount", "Mannequin", "Organization", "User"]
+
+    public static var selections: [GraphQLSelection] {
+      return [
+        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+        GraphQLField("login", type: .nonNull(.scalar(String.self))),
+      ]
+    }
+
+    public private(set) var resultMap: ResultMap
+
+    public init(unsafeResultMap: ResultMap) {
+      self.resultMap = unsafeResultMap
+    }
+
+    public static func makeBot(login: String) -> Author {
+      return Author(unsafeResultMap: ["__typename": "Bot", "login": login])
+    }
+
+    public static func makeEnterpriseUserAccount(login: String) -> Author {
+      return Author(unsafeResultMap: ["__typename": "EnterpriseUserAccount", "login": login])
+    }
+
+    public static func makeMannequin(login: String) -> Author {
+      return Author(unsafeResultMap: ["__typename": "Mannequin", "login": login])
+    }
+
+    public static func makeOrganization(login: String) -> Author {
+      return Author(unsafeResultMap: ["__typename": "Organization", "login": login])
+    }
+
+    public static func makeUser(login: String) -> Author {
+      return Author(unsafeResultMap: ["__typename": "User", "login": login])
+    }
+
+    public var __typename: String {
+      get {
+        return resultMap["__typename"]! as! String
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "__typename")
+      }
+    }
+
+    /// The username of the actor.
+    public var login: String {
+      get {
+        return resultMap["login"]! as! String
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "login")
+      }
+    }
+  }
+
+  public struct Commit: GraphQLSelectionSet {
+    public static let possibleTypes: [String] = ["PullRequestCommitConnection"]
+
+    public static var selections: [GraphQLSelection] {
+      return [
+        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+        GraphQLField("nodes", type: .list(.object(Node.selections))),
+      ]
+    }
+
+    public private(set) var resultMap: ResultMap
+
+    public init(unsafeResultMap: ResultMap) {
+      self.resultMap = unsafeResultMap
+    }
+
+    public init(nodes: [Node?]? = nil) {
+      self.init(unsafeResultMap: ["__typename": "PullRequestCommitConnection", "nodes": nodes.flatMap { (value: [Node?]) -> [ResultMap?] in value.map { (value: Node?) -> ResultMap? in value.flatMap { (value: Node) -> ResultMap in value.resultMap } } }])
+    }
+
+    public var __typename: String {
+      get {
+        return resultMap["__typename"]! as! String
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "__typename")
+      }
+    }
+
+    /// A list of nodes.
+    public var nodes: [Node?]? {
+      get {
+        return (resultMap["nodes"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [Node?] in value.map { (value: ResultMap?) -> Node? in value.flatMap { (value: ResultMap) -> Node in Node(unsafeResultMap: value) } } }
+      }
+      set {
+        resultMap.updateValue(newValue.flatMap { (value: [Node?]) -> [ResultMap?] in value.map { (value: Node?) -> ResultMap? in value.flatMap { (value: Node) -> ResultMap in value.resultMap } } }, forKey: "nodes")
+      }
+    }
+
+    public struct Node: GraphQLSelectionSet {
+      public static let possibleTypes: [String] = ["PullRequestCommit"]
+
+      public static var selections: [GraphQLSelection] {
+        return [
+          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+          GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
+        ]
+      }
+
+      public private(set) var resultMap: ResultMap
+
+      public init(unsafeResultMap: ResultMap) {
+        self.resultMap = unsafeResultMap
+      }
+
+      public init(id: GraphQLID) {
+        self.init(unsafeResultMap: ["__typename": "PullRequestCommit", "id": id])
+      }
+
+      public var __typename: String {
+        get {
+          return resultMap["__typename"]! as! String
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "__typename")
+        }
+      }
+
+      public var id: GraphQLID {
+        get {
+          return resultMap["id"]! as! GraphQLID
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "id")
+        }
+      }
+    }
+  }
+
+  public struct Label: GraphQLSelectionSet {
+    public static let possibleTypes: [String] = ["LabelConnection"]
+
+    public static var selections: [GraphQLSelection] {
+      return [
+        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+        GraphQLField("nodes", type: .list(.object(Node.selections))),
+      ]
+    }
+
+    public private(set) var resultMap: ResultMap
+
+    public init(unsafeResultMap: ResultMap) {
+      self.resultMap = unsafeResultMap
+    }
+
+    public init(nodes: [Node?]? = nil) {
+      self.init(unsafeResultMap: ["__typename": "LabelConnection", "nodes": nodes.flatMap { (value: [Node?]) -> [ResultMap?] in value.map { (value: Node?) -> ResultMap? in value.flatMap { (value: Node) -> ResultMap in value.resultMap } } }])
+    }
+
+    public var __typename: String {
+      get {
+        return resultMap["__typename"]! as! String
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "__typename")
+      }
+    }
+
+    /// A list of nodes.
+    public var nodes: [Node?]? {
+      get {
+        return (resultMap["nodes"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [Node?] in value.map { (value: ResultMap?) -> Node? in value.flatMap { (value: ResultMap) -> Node in Node(unsafeResultMap: value) } } }
+      }
+      set {
+        resultMap.updateValue(newValue.flatMap { (value: [Node?]) -> [ResultMap?] in value.map { (value: Node?) -> ResultMap? in value.flatMap { (value: Node) -> ResultMap in value.resultMap } } }, forKey: "nodes")
+      }
+    }
+
+    public struct Node: GraphQLSelectionSet {
+      public static let possibleTypes: [String] = ["Label"]
+
+      public static var selections: [GraphQLSelection] {
+        return [
+          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+          GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
+          GraphQLField("name", type: .nonNull(.scalar(String.self))),
+          GraphQLField("color", type: .nonNull(.scalar(String.self))),
+        ]
+      }
+
+      public private(set) var resultMap: ResultMap
+
+      public init(unsafeResultMap: ResultMap) {
+        self.resultMap = unsafeResultMap
+      }
+
+      public init(id: GraphQLID, name: String, color: String) {
+        self.init(unsafeResultMap: ["__typename": "Label", "id": id, "name": name, "color": color])
+      }
+
+      public var __typename: String {
+        get {
+          return resultMap["__typename"]! as! String
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "__typename")
+        }
+      }
+
+      public var id: GraphQLID {
+        get {
+          return resultMap["id"]! as! GraphQLID
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "id")
+        }
+      }
+
+      /// Identifies the label name.
+      public var name: String {
+        get {
+          return resultMap["name"]! as! String
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "name")
+        }
+      }
+
+      /// Identifies the label color.
+      public var color: String {
+        get {
+          return resultMap["color"]! as! String
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "color")
+        }
+      }
+    }
+  }
+
+  public struct Review: GraphQLSelectionSet {
+    public static let possibleTypes: [String] = ["PullRequestReviewConnection"]
+
+    public static var selections: [GraphQLSelection] {
+      return [
+        GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+        GraphQLField("nodes", type: .list(.object(Node.selections))),
+      ]
+    }
+
+    public private(set) var resultMap: ResultMap
+
+    public init(unsafeResultMap: ResultMap) {
+      self.resultMap = unsafeResultMap
+    }
+
+    public init(nodes: [Node?]? = nil) {
+      self.init(unsafeResultMap: ["__typename": "PullRequestReviewConnection", "nodes": nodes.flatMap { (value: [Node?]) -> [ResultMap?] in value.map { (value: Node?) -> ResultMap? in value.flatMap { (value: Node) -> ResultMap in value.resultMap } } }])
+    }
+
+    public var __typename: String {
+      get {
+        return resultMap["__typename"]! as! String
+      }
+      set {
+        resultMap.updateValue(newValue, forKey: "__typename")
+      }
+    }
+
+    /// A list of nodes.
+    public var nodes: [Node?]? {
+      get {
+        return (resultMap["nodes"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [Node?] in value.map { (value: ResultMap?) -> Node? in value.flatMap { (value: ResultMap) -> Node in Node(unsafeResultMap: value) } } }
+      }
+      set {
+        resultMap.updateValue(newValue.flatMap { (value: [Node?]) -> [ResultMap?] in value.map { (value: Node?) -> ResultMap? in value.flatMap { (value: Node) -> ResultMap in value.resultMap } } }, forKey: "nodes")
+      }
+    }
+
+    public struct Node: GraphQLSelectionSet {
+      public static let possibleTypes: [String] = ["PullRequestReview"]
+
+      public static var selections: [GraphQLSelection] {
+        return [
+          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+          GraphQLField("author", type: .object(Author.selections)),
+          GraphQLField("state", type: .nonNull(.scalar(PullRequestReviewState.self))),
+        ]
+      }
+
+      public private(set) var resultMap: ResultMap
+
+      public init(unsafeResultMap: ResultMap) {
+        self.resultMap = unsafeResultMap
+      }
+
+      public init(author: Author? = nil, state: PullRequestReviewState) {
+        self.init(unsafeResultMap: ["__typename": "PullRequestReview", "author": author.flatMap { (value: Author) -> ResultMap in value.resultMap }, "state": state])
+      }
+
+      public var __typename: String {
+        get {
+          return resultMap["__typename"]! as! String
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "__typename")
+        }
+      }
+
+      /// The actor who authored the comment.
+      public var author: Author? {
+        get {
+          return (resultMap["author"] as? ResultMap).flatMap { Author(unsafeResultMap: $0) }
+        }
+        set {
+          resultMap.updateValue(newValue?.resultMap, forKey: "author")
+        }
+      }
+
+      /// Identifies the current state of the pull request review.
+      public var state: PullRequestReviewState {
+        get {
+          return resultMap["state"]! as! PullRequestReviewState
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "state")
+        }
+      }
+
+      public struct Author: GraphQLSelectionSet {
+        public static let possibleTypes: [String] = ["Bot", "EnterpriseUserAccount", "Mannequin", "Organization", "User"]
+
+        public static var selections: [GraphQLSelection] {
+          return [
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+            GraphQLField("login", type: .nonNull(.scalar(String.self))),
+          ]
+        }
+
+        public private(set) var resultMap: ResultMap
+
+        public init(unsafeResultMap: ResultMap) {
+          self.resultMap = unsafeResultMap
+        }
+
+        public static func makeBot(login: String) -> Author {
+          return Author(unsafeResultMap: ["__typename": "Bot", "login": login])
+        }
+
+        public static func makeEnterpriseUserAccount(login: String) -> Author {
+          return Author(unsafeResultMap: ["__typename": "EnterpriseUserAccount", "login": login])
+        }
+
+        public static func makeMannequin(login: String) -> Author {
+          return Author(unsafeResultMap: ["__typename": "Mannequin", "login": login])
+        }
+
+        public static func makeOrganization(login: String) -> Author {
+          return Author(unsafeResultMap: ["__typename": "Organization", "login": login])
+        }
+
+        public static func makeUser(login: String) -> Author {
+          return Author(unsafeResultMap: ["__typename": "User", "login": login])
+        }
+
+        public var __typename: String {
+          get {
+            return resultMap["__typename"]! as! String
+          }
+          set {
+            resultMap.updateValue(newValue, forKey: "__typename")
+          }
+        }
+
+        /// The username of the actor.
+        public var login: String {
+          get {
+            return resultMap["login"]! as! String
+          }
+          set {
+            resultMap.updateValue(newValue, forKey: "login")
+          }
+        }
       }
     }
   }

--- a/PRChecker/Shared/GraphQL/NetworkService.swift
+++ b/PRChecker/Shared/GraphQL/NetworkService.swift
@@ -48,7 +48,7 @@ final class NetworkSerivce {
         username = keychainService[KeychainKey.username] ?? ""
         accessToken = keychainService[KeychainKey.accessToken] ?? ""
         apiEndpoint = keychainService[KeychainKey.apiEndpoint] ?? "https://api.github.com/graphql"
-        useLegacyQuery = keychainService[KeychainKey.legacyQueryFlag] != nil ? true : false
+        useLegacyQuery = UserDefaults.standard.bool(forKey: UserDefaultsKey.legacyQueries)
     }
         
     private(set) lazy var apollo: ApolloClient = {

--- a/PRChecker/Shared/GraphQL/NetworkService.swift
+++ b/PRChecker/Shared/GraphQL/NetworkService.swift
@@ -70,7 +70,7 @@ final class NetworkSerivce {
         return ApolloClient(networkTransport: requestChainTransport, store: store)
     }()
     
-    func initialize(for username: String, accessToken: String, endpoint: String, useLegacyQuery: Bool) {
+    func configure(for username: String, accessToken: String, endpoint: String, useLegacyQuery: Bool) {
         self.username = username
         self.accessToken = accessToken
         self.apiEndpoint = endpoint
@@ -78,39 +78,14 @@ final class NetworkSerivce {
     }
     
     func getAllPRs() -> AnyPublisher<(String, [AbstractPullRequest]), Error> {
-        if useLegacyQuery {
-            return getAllOldPRs(for: username)
-        } else {
-            return getAllNewPRs(for: username)
-        }
+        getAllPRs(for: username)
     }
     
-    func getAllPRs(for usernameList: [String]) -> AnyPublisher<(String, [AbstractPullRequest]), Error> {
-        if useLegacyQuery {
-            return Publishers.MergeMany(usernameList.map(getAllOldPRs(for:)))
-                .eraseToAnyPublisher()
-        } else {
-            return Publishers.MergeMany(usernameList.map(getAllNewPRs(for:)))
-                .eraseToAnyPublisher()
-        }
-    }
-}
-
-extension NetworkSerivce {
-    func getAllNewPRs(for usernameList: [String]) -> AnyPublisher<(String, [AbstractPullRequest]), Error> {
-        Publishers.MergeMany(usernameList.map(getAllNewPRs(for:)))
-            .eraseToAnyPublisher()
-    }
-    
-    func getAllNewPRs() -> AnyPublisher<(String, [AbstractPullRequest]), Error> {
-        getAllNewPRs(for: username)
-    }
-    
-    func getAllNewPRs(for username: String) -> AnyPublisher<(String, [AbstractPullRequest]), Error> {
+    func getAllPRs(for username: String) -> AnyPublisher<(String, [AbstractPullRequest]), Error> {
         let assignedQuery = "is:pr assignee:\(username) archived:false"
         let requestedQuery = "is:pr review-requested:\(username) archived:false"
         
-        return Publishers.Zip(getNewPR(with: assignedQuery), getNewPR(with: requestedQuery))
+        return Publishers.Zip(getPR(with: assignedQuery), getPR(with: requestedQuery))
             .map { prLists in
                 (prLists.0 + prLists.1).sorted { $0.rawUpdatedAt > $1.rawUpdatedAt }
             }
@@ -120,13 +95,24 @@ extension NetworkSerivce {
             .eraseToAnyPublisher()
     }
     
+    func getAllPRs(for usernameList: [String]) -> AnyPublisher<(String, [AbstractPullRequest]), Error> {
+        Publishers.MergeMany(usernameList.map(getAllPRs(for:)))
+            .eraseToAnyPublisher()
+    }
+    
+    func getPR(with query: String) -> AnyPublisher<[AbstractPullRequest], Error> {
+        guard !username.isEmpty, !accessToken.isEmpty, !apiEndpoint.isEmpty else {
+            return Fail(error: NetworkServiceError.missingLogin).eraseToAnyPublisher()
+        }
+        
+        guard !useLegacyQuery else { return getOldPR(with: query) }
+        return getNewPR(with: query)
+    }
+}
+
+extension NetworkSerivce {
     func getNewPR(with query: String) -> AnyPublisher<[AbstractPullRequest], Error> {
         let resultPublisher = PassthroughSubject<[AbstractPullRequest], Error>()
-        
-        guard !username.isEmpty, !accessToken.isEmpty, !apiEndpoint.isEmpty else {
-            resultPublisher.send(completion: .failure(NetworkServiceError.missingLogin))
-            return resultPublisher.eraseToAnyPublisher()
-        }
         
         apollo.fetch(
             query: GetAssignedPRsWithQueryQuery(query: query),
@@ -152,36 +138,8 @@ extension NetworkSerivce {
 }
 
 extension NetworkSerivce {
-    func getAllOldPRs(for usernameList: [String]) -> AnyPublisher<(String, [AbstractPullRequest]), Error> {
-        Publishers.MergeMany(usernameList.map(getAllOldPRs(for:)))
-            .eraseToAnyPublisher()
-    }
-    
-    func getAllOldPRs() -> AnyPublisher<(String, [AbstractPullRequest]), Error> {
-        getAllOldPRs(for: username)
-    }
-    
-    func getAllOldPRs(for username: String) -> AnyPublisher<(String, [AbstractPullRequest]), Error> {
-        let assignedQuery = "is:pr assignee:\(username) archived:false"
-        let requestedQuery = "is:pr review-requested:\(username) archived:false"
-        
-        return Publishers.Zip(getOldPR(with: assignedQuery), getOldPR(with: requestedQuery))
-            .map { prLists in
-                (prLists.0 + prLists.1).sorted { $0.rawUpdatedAt > $1.rawUpdatedAt }
-            }
-            .map{ prList in
-                (username, prList)
-            }
-            .eraseToAnyPublisher()
-    }
-    
     func getOldPR(with query: String) -> AnyPublisher<[AbstractPullRequest], Error> {
         let resultPublisher = PassthroughSubject<[AbstractPullRequest], Error>()
-        
-        guard !username.isEmpty, !accessToken.isEmpty, !apiEndpoint.isEmpty else {
-            resultPublisher.send(completion: .failure(NetworkServiceError.missingLogin))
-            return resultPublisher.eraseToAnyPublisher()
-        }
         
         apollo.fetch(
             query: GetOldAssignedPRsWithQueryQuery(query: query),

--- a/PRChecker/Shared/GraphQL/Queries.graphql
+++ b/PRChecker/Shared/GraphQL/Queries.graphql
@@ -43,6 +43,53 @@ fragment PRInfo on PullRequest {
     updatedAt
 }
 
+fragment OldPRInfo on PullRequest {
+    id
+        
+    url
+        
+    repository {
+        id
+        nameWithOwner
+    }
+    baseRefName
+    headRefName
+        
+    author {
+        login
+    }
+    title
+    body
+        
+    changedFiles
+    additions
+    deletions
+    commits(last: 100) {
+        nodes {
+            id
+        }
+    }
+    labels(last: 10) {
+        nodes {
+            id
+            name
+            color
+        }
+    }
+
+    state
+    reviews(last: 100) {
+        nodes {
+            author {
+                login
+            }
+            state
+        }
+    }
+    mergedAt
+    updatedAt
+}
+
 query GetPRsByAuthor($author: String!) {
     user(login: $author) {
         id
@@ -61,6 +108,18 @@ query GetAssignedPRsWithQuery($query: String!) {
             node {
                 ... on PullRequest {
                     ...PRInfo
+                }
+            }
+        }
+    }
+}
+
+query GetOldAssignedPRsWithQuery($query: String!) {
+    search(last: 100, query: $query, type: ISSUE) {
+        edges {
+            node {
+                ... on PullRequest {
+                    ...OldPRInfo
                 }
             }
         }

--- a/PRChecker/Shared/Models/AbstractPullRequest.swift
+++ b/PRChecker/Shared/Models/AbstractPullRequest.swift
@@ -1,0 +1,191 @@
+//
+//  AbstractPullRequest.swift
+//  PRChecker
+//
+//  Created by Bruce Evans on 2021/11/09.
+//
+
+import Foundation
+import Apollo
+import SwiftUI
+
+enum PRState: String {
+    case open = "Open"
+    case merged = "Merged"
+    case closed = "Closed"
+    
+    var color: Color {
+        switch self {
+        case .open:
+            return .green
+        case .merged:
+            return .orange
+        case .closed:
+            return .red
+        }
+    }
+}
+
+enum ViewerStatus: String {
+    case waiting = "Waiting"
+    case commented = "Commented"
+    case blocked = "Blocked"
+    case approved = "Approved"
+    
+    var color: Color {
+        switch self {
+        case .waiting:
+            return .orange
+        case .commented:
+            return .yellow
+        case .blocked:
+            return .red
+        case .approved:
+            return .green
+        }
+    }
+}
+
+protocol LabelNode {
+    var id: GraphQLID { get }
+    var name: String { get }
+    var color: String { get }
+}
+
+extension PrInfo.Label.Node: LabelNode {}
+extension OldPrInfo.Label.Node: LabelNode {}
+
+struct LabelModel {
+    let labelConnection: LabelNode
+
+    var id: GraphQLID {
+        labelConnection.id
+    }
+    
+    var title: String {
+        labelConnection.name
+    }
+    
+    var color: Color {
+        return .init(hexValue: labelConnection.color)
+    }
+}
+
+extension LabelModel: Equatable {
+    static func == (lhs: LabelModel, rhs: LabelModel) -> Bool {
+        lhs.id == rhs.id && lhs.title == rhs.title
+    }
+}
+
+struct HeaderViewModel {
+    let repoName: String
+    let status: PRState
+    let title: String
+    let targetBranch: String
+    let headBranch: String
+    
+}
+
+struct ContentViewModel {
+    let author: String
+    let additions: String
+    let deletions: String
+    let commits: String
+    let description: String
+    let labels: [LabelModel]
+}
+
+struct FooterViewModel {
+    let status: ViewerStatus
+    let updatedTime: String
+}
+
+// Do not use this class directly
+class AbstractPullRequest: ObservableObject, Identifiable {
+    lazy var headerViewModel: HeaderViewModel = {
+        HeaderViewModel(
+            repoName: repositoryName,
+            status: state,
+            title: title,
+            targetBranch: targetBranch,
+            headBranch: headBranch
+        )
+    }()
+    
+    lazy var contentViewModel: ContentViewModel = {
+        ContentViewModel(
+            author: author,
+            additions: "+\(lineAdditions)",
+            deletions: "-\(lineDeletions)",
+            commits: "\(commits.count) commits",
+            description: body,
+            labels: labels
+        )
+    }()
+    
+    lazy var footerViewModel: FooterViewModel = {
+        FooterViewModel(
+            status: viewerStatus,
+            updatedTime: updatedAt
+        )
+    }()
+    
+    var id: GraphQLID { GraphQLID("!!") }
+    
+    var isRead: Bool { false }
+    
+    var url: String { "" }
+    
+    var repositoryName: String { "" }
+    
+    var targetBranch: String { "" }
+    
+    var headBranch: String { "" }
+    
+    var author: String { "" }
+    
+    var title: String { "" }
+    
+    var body: String { "" }
+    
+    var changedFileCount: Int { 0 }
+    
+    var lineAdditions: Int { 0 }
+    
+    var lineDeletions: Int { 0 }
+    
+    var commits: [GraphQLID] { [] }
+    
+    var labels: [LabelModel] { [] }
+    
+    var state: PRState { .closed }
+    
+    var viewerStatus: ViewerStatus { .waiting }
+    
+    var mergedAt: String? { nil }
+    
+    var rawUpdatedAt: String { "" }
+    
+    var updatedAt: String { "" }
+    
+    private static let dateFormatter = ISO8601DateFormatter()
+    
+    private static let secondsPerDay: Double = 60 * 60 * 24
+    private static let secondsPerHour: Double = 60 * 60
+    private static let secondsPerMinute: Double = 60
+    
+    class func relativeDateString(from dateString: String) -> String {
+        let date = dateFormatter.date(from: dateString) ?? Date()
+        let offset = abs(date.timeIntervalSinceNow)
+        
+        if offset / secondsPerDay > 1 {
+            return "\(Int(floor(offset / secondsPerDay)))d"
+        } else if offset /  secondsPerHour > 1 {
+            return "\(Int(floor(offset / secondsPerHour)))h"
+        } else if offset / secondsPerMinute > 1 {
+            return "\(Int(floor(offset / secondsPerMinute)))m"
+        } else {
+            return "1m"
+        }
+    }
+}

--- a/PRChecker/Shared/Models/OldPullRequest.swift
+++ b/PRChecker/Shared/Models/OldPullRequest.swift
@@ -92,7 +92,7 @@ class OldPullRequest: AbstractPullRequest {
             return .waiting     // No reviews at all
         }
         
-        guard let viewersReview = nodes.first(where: { $0?.author?.login == username }) else {
+        guard let viewersReview = nodes.last(where: { $0?.author?.login == username }) else {
             return .waiting     // Viewer has not reviewed
         }
         

--- a/PRChecker/Shared/Models/OldPullRequest.swift
+++ b/PRChecker/Shared/Models/OldPullRequest.swift
@@ -1,19 +1,21 @@
 //
-//  PullRequest.swift
+//  OldPullRequest.swift
 //  PRChecker
 //
-//  Created by Bruce Evans on 2021/11/03.
+//  Created by Bruce Evans on 2021/11/09.
 //
 
 import Foundation
 import Apollo
 import SwiftUI
 
-class PullRequest: AbstractPullRequest {
-    let pullRequest: PrInfo
+class OldPullRequest: AbstractPullRequest {
+    let pullRequest: OldPrInfo
+    let username: String
     
-    init(pullRequest: PrInfo) {
+    init(pullRequest: OldPrInfo, username: String) {
         self.pullRequest = pullRequest
+        self.username = username
     }
     
     override var id: GraphQLID {
@@ -21,7 +23,7 @@ class PullRequest: AbstractPullRequest {
     }
     
     override var isRead: Bool {
-        pullRequest.isReadByViewer ?? false
+        false   // TODO: Can we get this data somewhere else?
     }
     
     override var url: String {
@@ -86,7 +88,15 @@ class PullRequest: AbstractPullRequest {
     }
     
     override var viewerStatus: ViewerStatus {
-        switch pullRequest.viewerLatestReview?.state {
+        guard let nodes = pullRequest.reviews?.nodes else {
+            return .waiting     // No reviews at all
+        }
+        
+        guard let viewersReview = nodes.first(where: { $0?.author?.login == username }) else {
+            return .waiting     // Viewer has not reviewed
+        }
+        
+        switch viewersReview?.state {
         case .none, .pending, .dismissed:
             return .waiting
         case .approved:
@@ -96,7 +106,7 @@ class PullRequest: AbstractPullRequest {
         case .commented:
             return .commented
         default:
-            assertionFailure("Unknown status: \(String(describing: pullRequest.viewerLatestReview?.state))")
+            assertionFailure("Unknown status: \(String(describing: viewersReview?.state))")
             return .waiting
         }
     }

--- a/PRChecker/Shared/Unique Views/LoginView.swift
+++ b/PRChecker/Shared/Unique Views/LoginView.swift
@@ -22,7 +22,7 @@ struct LoginView: View {
     
     var body: some View {
         HStack {
-            VStack {
+            VStack(alignment: .leading) {
                 TextField(LocalizedStringKey("Username"), text: $loginInfo.username)
                 HStack {
                     TextField(LocalizedStringKey("Access Token"), text: $loginInfo.accessToken)
@@ -37,6 +37,10 @@ struct LoginView: View {
                     }
                 }
                 TextField(LocalizedStringKey("API Endpoint"), text: $loginInfo.apiEndpoint)
+                Toggle(isOn: $loginInfo.useLegacyQuery) {
+                    Text("Use Legacy Queries")
+                }
+                // TODO: Some sort of guidance on the legacy query usage
             }
         }
         .padding(20)

--- a/PRChecker/Shared/Unique Views/PRListView.swift
+++ b/PRChecker/Shared/Unique Views/PRListView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct PRListView: View {
-    @Environment(\.openURL) var openURL
     @EnvironmentObject var filterViewModel: FilterViewModel
     
     @ObservedObject var prListViewModel = PRListViewModel()
@@ -26,32 +25,13 @@ struct PRListView: View {
             LazyVGrid(columns: [GridItem(.adaptive(minimum: 300))], alignment: .leading, pinnedViews: [.sectionHeaders]) {
                 
                 if let filteredPRList = myPRManager.prList.filter(filterViewModel.combinedFilter?.filter ?? { _ in true }), !filteredPRList.isEmpty {
-                    Section(header: Rectangle().frame(height: 45).foregroundColor(.gray5).overlay(Text("You").font(.title).bold().padding(.leading), alignment: .leading)) {
-                        ForEach(filteredPRList, id: \.id) { pullRequest in
-                            PullRequestCell(pullRequest: pullRequest)
-                                .cornerRadius(16)
-                                .overlay(RoundedRectangle(cornerRadius: 16).stroke(Color.gray3, lineWidth: 1))
-                                .onTapGesture {
-                                    openURL(URL(string: pullRequest.url)!)
-                                }
-                        }
-                    }
+                    PRSectionView(name: "You", prList: filteredPRList)
                 }
                 
                 
                 ForEach(watchedUserViewModel.prList, id: \.0) { (name, prList) in
                     if let filteredPRList = prList.filter(filterViewModel.combinedFilter?.filter ?? { _ in true }), !filteredPRList.isEmpty {
-                        
-                        Section(header: Rectangle().frame(height: 45).foregroundColor(.gray5).overlay(Text(name).font(.title).bold().padding(.leading), alignment: .leading)) {
-                            ForEach(filteredPRList, id: \.id) { pullRequest in
-                                PullRequestCell(pullRequest: pullRequest)
-                                    .cornerRadius(16)
-                                    .overlay(RoundedRectangle(cornerRadius: 16).stroke(Color.gray3, lineWidth: 1))
-                                    .onTapGesture {
-                                        openURL(URL(string: pullRequest.url)!)
-                                    }
-                            }
-                        }
+                        PRSectionView(name: name, prList: filteredPRList)
                     }
                     
                 }
@@ -76,6 +56,43 @@ struct PRListView: View {
             let combinedFilters = repositorySection.filters + (filters?["Repository"] ?? [])
             repositorySection.filters = combinedFilters.arrayByRemovingDuplicates().sorted { $0.name < $1.name }
         }
+    }
+}
+
+struct PRSectionView: View {
+    let name: String
+    let prList: [AbstractPullRequest]
+    
+    @Environment(\.openURL) var openURL
+    
+    var body: some View {
+        Section(header: PRSectionHeaderView(name: name)) {
+            ForEach(prList, id: \.id) { pullRequest in
+                PullRequestCell(pullRequest: pullRequest)
+                    .cornerRadius(16)
+                    .overlay(RoundedRectangle(cornerRadius: 16).stroke(Color.gray3, lineWidth: 1))
+                    .onTapGesture {
+                        openURL(URL(string: pullRequest.url)!)
+                    }
+            }
+        }
+    }
+}
+
+struct PRSectionHeaderView: View {
+    let name: String
+    
+    var body: some View {
+        Rectangle()
+            .frame(height: 45)
+            .foregroundColor(.gray5)
+            .overlay(
+                Text(name)
+                    .font(.title)
+                    .bold()
+                    .padding(.leading),
+                alignment: .leading
+            )
     }
 }
 

--- a/PRChecker/Shared/Unique Views/PullRequestCell.swift
+++ b/PRChecker/Shared/Unique Views/PullRequestCell.swift
@@ -39,7 +39,7 @@ struct PullRequestCell: View {
 
 private struct Header: View {
     
-    let header: PullRequest.Header
+    let header: HeaderViewModel
 
     @Binding var isHover: Bool
     
@@ -108,7 +108,7 @@ private struct BranchLabel: View {
 
 private struct ContentBody: View {
 
-    let content: PullRequest.Content
+    let content: ContentViewModel
 
     @Binding var isHover: Bool
     
@@ -168,7 +168,7 @@ private struct ContentBody: View {
 
 private struct Footer: View {
     
-    let footer: PullRequest.Footer
+    let footer: FooterViewModel
     
     var body: some View {
         VStack {

--- a/PRChecker/Shared/Unique Views/PullRequestCell.swift
+++ b/PRChecker/Shared/Unique Views/PullRequestCell.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct PullRequestCell: View {
     
-    let pullRequest: PullRequest
+    let pullRequest: AbstractPullRequest
 
     @State private var isHover = false
     

--- a/PRChecker/Shared/ViewModels/FilterViewModel.swift
+++ b/PRChecker/Shared/ViewModels/FilterViewModel.swift
@@ -102,11 +102,11 @@ extension FilterSection: Equatable {
 class Filter: ObservableObject {
     var name: String
     
-    var filter: (PullRequest) -> Bool
+    var filter: (AbstractPullRequest) -> Bool
     
     @Published var isEnabled: Bool = false
     
-    init(name: String, filter: @escaping (PullRequest) -> Bool) {
+    init(name: String, filter: @escaping (AbstractPullRequest) -> Bool) {
         self.name = name
         self.filter = filter
     }

--- a/PRChecker/Shared/ViewModels/LoginInfoViewModel.swift
+++ b/PRChecker/Shared/ViewModels/LoginInfoViewModel.swift
@@ -13,6 +13,7 @@ struct LoginInfoViewModel {
     var username: String
     var accessToken: String
     var apiEndpoint: String
+    var useLegacyQuery: Bool
     
     var canLogin: Bool {
         !username.isEmpty && !accessToken.isEmpty && !apiEndpoint.isEmpty
@@ -23,6 +24,7 @@ struct LoginInfoViewModel {
         username = keychainService[KeychainKey.username] ?? ""
         accessToken = keychainService[KeychainKey.accessToken] ?? ""
         apiEndpoint = keychainService[KeychainKey.apiEndpoint] ?? "https://api.github.com/graphql"
+        useLegacyQuery = keychainService[KeychainKey.legacyQueryFlag] != nil ? true : false
     }
 
     func saveToKeychain() {
@@ -30,8 +32,9 @@ struct LoginInfoViewModel {
         keychainService[KeychainKey.apiEndpoint] = apiEndpoint
         keychainService[KeychainKey.username] = username
         keychainService[KeychainKey.accessToken] = accessToken
+        keychainService[KeychainKey.legacyQueryFlag] = useLegacyQuery ? "1" : nil
         
-        NetworkSerivce.shared.initialize(for: username, accessToken: accessToken, endpoint: apiEndpoint)
+        NetworkSerivce.shared.initialize(for: username, accessToken: accessToken, endpoint: apiEndpoint, useLegacyQuery: useLegacyQuery)
     }
 }
 

--- a/PRChecker/Shared/ViewModels/LoginInfoViewModel.swift
+++ b/PRChecker/Shared/ViewModels/LoginInfoViewModel.swift
@@ -34,7 +34,7 @@ struct LoginInfoViewModel {
         keychainService[KeychainKey.accessToken] = accessToken
         keychainService[KeychainKey.legacyQueryFlag] = useLegacyQuery ? "1" : nil
         
-        NetworkSerivce.shared.initialize(for: username, accessToken: accessToken, endpoint: apiEndpoint, useLegacyQuery: useLegacyQuery)
+        NetworkSerivce.shared.configure(for: username, accessToken: accessToken, endpoint: apiEndpoint, useLegacyQuery: useLegacyQuery)
     }
 }
 

--- a/PRChecker/Shared/ViewModels/LoginInfoViewModel.swift
+++ b/PRChecker/Shared/ViewModels/LoginInfoViewModel.swift
@@ -24,7 +24,7 @@ struct LoginInfoViewModel {
         username = keychainService[KeychainKey.username] ?? ""
         accessToken = keychainService[KeychainKey.accessToken] ?? ""
         apiEndpoint = keychainService[KeychainKey.apiEndpoint] ?? "https://api.github.com/graphql"
-        useLegacyQuery = keychainService[KeychainKey.legacyQueryFlag] != nil ? true : false
+        useLegacyQuery = UserDefaults.standard.bool(forKey: UserDefaultsKey.legacyQueries)
     }
 
     func saveToKeychain() {
@@ -32,7 +32,7 @@ struct LoginInfoViewModel {
         keychainService[KeychainKey.apiEndpoint] = apiEndpoint
         keychainService[KeychainKey.username] = username
         keychainService[KeychainKey.accessToken] = accessToken
-        keychainService[KeychainKey.legacyQueryFlag] = useLegacyQuery ? "1" : nil
+        UserDefaults.standard.set(useLegacyQuery, forKey: UserDefaultsKey.legacyQueries)
         
         NetworkSerivce.shared.configure(for: username, accessToken: accessToken, endpoint: apiEndpoint, useLegacyQuery: useLegacyQuery)
     }

--- a/PRChecker/Shared/ViewModels/WatchedUserViewModel.swift
+++ b/PRChecker/Shared/ViewModels/WatchedUserViewModel.swift
@@ -9,7 +9,7 @@ import Combine
 import Foundation
 
 class WatchedUserViewModel: ObservableObject {
-    @Published var prList = [(String, [PullRequest])]()
+    @Published var prList = [(String, [AbstractPullRequest])]()
     @Published var additionalFilters: [String: [Filter]]?
     
     private var subscriptions = Set<AnyCancellable>()

--- a/PRChecker/macOS/Unique Views/MenuBarPRCell.swift
+++ b/PRChecker/macOS/Unique Views/MenuBarPRCell.swift
@@ -11,7 +11,7 @@ struct MenuBarPRCell: View {
 
     @State private var isHover = false
 
-    let pullRequest: PullRequest
+    let pullRequest: AbstractPullRequest
 
     var body: some View {
         VStack(alignment: .leading) {


### PR DESCRIPTION
When testing with my company's Github Enterprise, I found that the GraphQL queries were out of date. Since using this in an Enterprise environment is one of the goals, I updated some of the logic to support GE 2.20.

Most of the changes are behind the scenes, but I did add a "Use Legacy Queries" checkbox to the Login View.

I'm curious what you think about this, so for now, please review without merging.