### PR TITLE
[Test PR] 

### DIFF
--- a/PRChecker/Shared/Unique Views/ContentView.swift
+++ b/PRChecker/Shared/Unique Views/ContentView.swift
@@ -56,6 +56,9 @@ struct ContentView: View {
                     .frame(width: 300, height: geometry.size.height)
             }
             .frame(width: geometry.size.width, height: geometry.size.height)
+            .onReceive(NotificationCenter.default.publisher(for: NSApplication.willBecomeActiveNotification)) { _ in
+                prListViewModel.getPRList()
+            }
         }
     }
 }

--- a/PRChecker/Shared/ViewModels/PRListViewModel.swift
+++ b/PRChecker/Shared/ViewModels/PRListViewModel.swift
@@ -14,6 +14,15 @@ class PRListViewModel: ObservableObject {
     
     private var subscriptions = Set<AnyCancellable>()
     
+    init() {
+        Timer.publish(every: 600, tolerance: 15, on: .main, in: .default)
+            .autoconnect()
+            .sink { _ in
+                self.getPRList()
+            }
+            .store(in: &subscriptions)
+    }
+    
     func getPRList(completion: (() -> Void)? = nil) {
         NetworkSerivce.shared.getAllPRs()
             .sink { error in


### PR DESCRIPTION
I came up with two options for timers. 

The first is the first commit, and it uses an indefinite Timer publisher every 5 minutes. Unfortunately, when I tested it, the timer only seemed to count time in the foreground, and there were very few background updates.

The second was a different idea. Like the menuBar, instead of updating on a timer, just update when it comes into the foreground.

What do you think about these? Have any other ideas?