### PR TITLE
Rework the settings view UI.

### DIFF
--- a/PRChecker/Shared/PRCheckerApp.swift
+++ b/PRChecker/Shared/PRCheckerApp.swift
@@ -19,7 +19,7 @@ struct PRCheckerApp: App {
             ContentView()
                 .environmentObject(FilterViewModel())
                 .background(Color.gray6)
-                .frame(minWidth: 725, minHeight: 375)
+                .frame(minWidth: 655, minHeight: 375)
         }
     }
 }

--- a/PRChecker/Shared/Unique Views/ContentView.swift
+++ b/PRChecker/Shared/Unique Views/ContentView.swift
@@ -15,38 +15,6 @@ struct ContentView: View {
     var body: some View {
         GeometryReader { geometry in
             HStack {
-                VStack {
-                    Spacer()
-                    Button {
-                        showLogin.toggle()
-                    } label: {
-                        Text(.init(systemName: "person"))
-                            .font(.system(size: 45))
-                            .fontWeight(.thin)
-                            .foregroundColor(.secondary)
-                    }
-                    .buttonStyle(LinkButtonStyle())
-                    .popover(isPresented: $showLogin, arrowEdge: .trailing) {
-                        LoginView()
-                            .onDisappear {
-                                prListViewModel.getPRList()
-                            }
-                    }
-
-                    Button {
-                        showSettings.toggle()
-                    } label: {
-                        Text(.init(systemName: "gearshape"))
-                            .font(.system(size: 45))
-                            .fontWeight(.thin)
-                            .foregroundColor(.secondary)
-                    }
-                    .buttonStyle(LinkButtonStyle())
-                    .popover(isPresented: $showSettings, arrowEdge: .trailing) {
-                        SettingsView()
-                    }
-                }
-                .padding([.leading, .bottom, .top])
                 Divider()
                     .background(Color.gray5)
                 PRListView(prListViewModel: prListViewModel)
@@ -58,6 +26,33 @@ struct ContentView: View {
             }
             .frame(width: geometry.size.width, height: geometry.size.height)
         }
+        .overlay(
+            HStack {
+                VStack {
+                    Spacer()
+                    
+                    Button {
+                        showSettings.toggle()
+                    } label: {
+                        Text(.init(systemName: "gearshape"))
+                            .font(.system(size: 45))
+                            .fontWeight(.thin)
+                            .foregroundColor(.secondary)
+                    }
+                    .buttonStyle(LinkButtonStyle())
+                    .popover(isPresented: $showSettings, arrowEdge: .bottom) {
+                        SettingsView()
+                            .frame(minWidth: 200, maxHeight: 800, alignment: .leading)
+                            .onDisappear { prListViewModel.getPRList() }
+                    }
+                    .padding(8)
+                    .background(Color.gray4.clipShape(Circle()))
+                }
+                .padding([.leading, .bottom])
+                
+                Spacer()
+            }
+        )
     }
 }
 

--- a/PRChecker/Shared/Unique Views/LoginView.swift
+++ b/PRChecker/Shared/Unique Views/LoginView.swift
@@ -42,7 +42,6 @@ struct LoginView: View {
             }
         }
         .padding(20)
-        .frame(maxWidth: 400, maxHeight: 200, alignment: .center)
         .onDisappear {
             loginInfo.saveToKeychain()
         }

--- a/PRChecker/Shared/Unique Views/PRListView.swift
+++ b/PRChecker/Shared/Unique Views/PRListView.swift
@@ -78,7 +78,7 @@ struct PRSectionHeaderView: View {
     let name: String
     
     var body: some View {
-        Rectangle()
+        RoundedRectangle(cornerRadius: 10)
             .frame(height: 45)
             .foregroundColor(.gray5)
             .overlay(

--- a/PRChecker/Shared/Unique Views/SettingsView.swift
+++ b/PRChecker/Shared/Unique Views/SettingsView.swift
@@ -9,56 +9,76 @@ import SwiftUI
 
 struct SettingsView: View {
     @State var settingsViewModel = SettingsViewModel()
-    
-    @State var height: Double = 250
-    
+        
     var body: some View {
-        VStack(alignment: .leading) {
-            ScrollView {
-                ForEach(settingsViewModel.userList, id: \.self) { user in
-                    HStack {
-                        Image(systemName: "person.fill")
-                            .font(.title)
-                        Text(user)
-                            .font(.title)
-                        Spacer()
-                        Button {
-                            settingsViewModel.remove(user)
-                        } label: {
-                            Image(systemName: "x.circle.fill")
-                                .foregroundColor(.red)
-                        }
-                        .buttonStyle(PlainButtonStyle())
+        ScrollView {
+            VStack(alignment: .leading) {
+                LoginView()
+                    .frame(maxWidth: 600, maxHeight: 200, alignment: .leading)
+                
+                Divider()
+                
+                List {
+                    ForEach(settingsViewModel.userList, id: \.self) { user in
+                        WatchedUserView(username: user) { settingsViewModel.remove($0) }
                     }
-                    .padding([.leading, .trailing, .top])
+                    .onDelete { indexSet in
+                        settingsViewModel.remove(indexSet)
+                    }
                 }
+                .frame(height: 300)
+                
+                Spacer()
+                AddUserView() { settingsViewModel.addUser($0) }
+                .padding([.leading, .trailing])
             }
-            .frame(
-                minWidth: 200,
-                maxWidth: .infinity,
-                idealHeight: height,
-                maxHeight: height
-            )
-            .onChange(of: settingsViewModel.userList) { newValue in
-                height = newValue.isEmpty ? 0 : 250
-            }
-            
-            Spacer()
-            HStack {
-                TextField(LocalizedStringKey("Username"), text: $settingsViewModel.newUsername)
-                Button("Add") {
-                    settingsViewModel.addUser()
-                }
-            }
-            .padding([.leading, .trailing])
+            .padding()
         }
         .padding(20)
-        .frame(minWidth: 200, minHeight: height, maxHeight: 400, alignment: .leading)
     }
 }
 
 struct SettingsView_Previews: PreviewProvider {
     static var previews: some View {
         SettingsView()
+    }
+}
+
+struct WatchedUserView: View {
+    var username: String
+    var onRemove: ((String) -> Void)?
+    
+    var body: some View {
+        HStack {
+            Image(systemName: "person.fill")
+                .font(.title)
+            Text(username)
+                .font(.title)
+            Spacer()
+            Button {
+                onRemove?(username)
+            } label: {
+                Image(systemName: "x.circle.fill")
+                    .foregroundColor(.red)
+            }
+            .buttonStyle(PlainButtonStyle())
+        }
+        .padding([.leading, .trailing, .top])
+    }
+}
+
+struct AddUserView: View {
+    @State var newUsername = ""
+    var onAdd: ((String) -> Void)?
+    
+    var body: some View {
+        HStack {
+            TextField(LocalizedStringKey("Username"), text: $newUsername)
+            Button("Add") {
+                guard !newUsername.isEmpty else { return }
+                onAdd?(newUsername)
+                newUsername = ""
+            }
+        }
     }
 }

--- a/PRChecker/Shared/ViewModels/SettingsViewModel.swift
+++ b/PRChecker/Shared/ViewModels/SettingsViewModel.swift
@@ -9,9 +9,8 @@ import Foundation
 
 struct SettingsViewModel {
     var userList: [String]
-    
-    var newUsername: String = ""
-    
+    var legacyMode: Bool = false
+        
     init() {
         if let existingUserList = UserDefaults.standard.userList {
             userList = existingUserList
@@ -20,10 +19,9 @@ struct SettingsViewModel {
         }
     }
     
-    mutating func addUser() {
-        guard !newUsername.isEmpty else { return }
-        userList = ([newUsername.lowercased()] + userList).arrayByRemovingDuplicates().sorted(by: <)
-        newUsername = ""
+    mutating func addUser(_ username: String) {
+        guard !username.isEmpty else { return }
+        userList = ([username.lowercased()] + userList).arrayByRemovingDuplicates().sorted(by: <)
         UserDefaults.standard.userList = userList
     }
     
@@ -31,6 +29,11 @@ struct SettingsViewModel {
         userList.removeAll { name in
             name.lowercased() == username.lowercased()
         }
+        UserDefaults.standard.userList = userList
+    }
+    
+    mutating func remove(_ indexSet: IndexSet) {
+        userList.remove(atOffsets: indexSet)
         UserDefaults.standard.userList = userList
     }
 }


### PR DESCRIPTION
Combines the Login view with the settings view.

Also turns the Watched User list into an actual list:
<img width="932" alt="settings" src="https://user-images.githubusercontent.com/4517072/141614214-f6c7861f-a55e-476b-a6be-e261b303d062.png">


Also, since the login view is now in settings, we don't need the odd sidebar, so I removed that and replaced it with a floating button. I could probably use a drop shadow though.
<img width="767" alt="minimum" src="https://user-images.githubusercontent.com/4517072/141614225-0fcab70a-e04c-43f6-b207-734f9c8cf448.png">

