### PR TITLE
Fix Uniqueness of PR IDs

### DIFF
--- a/PRChecker/Shared/Models/AbstractPullRequest.swift
+++ b/PRChecker/Shared/Models/AbstractPullRequest.swift
@@ -130,6 +130,14 @@ class AbstractPullRequest: ObservableObject, Identifiable {
         )
     }()
     
+    init(currentUser: String) {
+        self.currentUser = currentUser
+    }
+    
+    var currentUser: String
+    
+    var idBySection: String { id + currentUser }
+    
     var id: GraphQLID { GraphQLID("!!") }
     
     var isRead: Bool { false }

--- a/PRChecker/Shared/Models/OldPullRequest.swift
+++ b/PRChecker/Shared/Models/OldPullRequest.swift
@@ -11,11 +11,12 @@ import SwiftUI
 
 class OldPullRequest: AbstractPullRequest {
     let pullRequest: OldPrInfo
-    let username: String
+    let viewingUser: String
     
-    init(pullRequest: OldPrInfo, username: String) {
+    init(pullRequest: OldPrInfo, currentUser: String, viewingUser: String) {
         self.pullRequest = pullRequest
-        self.username = username
+        self.viewingUser = viewingUser
+        super.init(currentUser: currentUser)
     }
     
     override var id: GraphQLID {
@@ -92,7 +93,7 @@ class OldPullRequest: AbstractPullRequest {
             return .waiting     // No reviews at all
         }
         
-        guard let viewersReview = nodes.last(where: { $0?.author?.login == username }) else {
+        guard let viewersReview = nodes.last(where: { $0?.author?.login == viewingUser }) else {
             return .waiting     // Viewer has not reviewed
         }
         

--- a/PRChecker/Shared/Models/PullRequest.swift
+++ b/PRChecker/Shared/Models/PullRequest.swift
@@ -12,8 +12,9 @@ import SwiftUI
 class PullRequest: AbstractPullRequest {
     let pullRequest: PrInfo
     
-    init(pullRequest: PrInfo) {
+    init(pullRequest: PrInfo, currentUser: String) {
         self.pullRequest = pullRequest
+        super.init(currentUser: currentUser)
     }
     
     override var id: GraphQLID {

--- a/PRChecker/Shared/Unique Views/PRListView.swift
+++ b/PRChecker/Shared/Unique Views/PRListView.swift
@@ -62,7 +62,7 @@ struct PRSectionView: View {
     
     var body: some View {
         Section(header: PRSectionHeaderView(name: name)) {
-            ForEach(prList, id: \.id) { pullRequest in
+            ForEach(prList, id: \.idBySection) { pullRequest in
                 PullRequestCell(pullRequest: pullRequest)
                     .cornerRadius(16)
                     .overlay(RoundedRectangle(cornerRadius: 16).stroke(Color.gray3, lineWidth: 1))

--- a/PRChecker/Shared/Unique Views/PullRequestCell.swift
+++ b/PRChecker/Shared/Unique Views/PullRequestCell.swift
@@ -194,7 +194,7 @@ private struct Footer: View {
 struct PullRequestCell_Previews: PreviewProvider {
     static var previews: some View {
         ForEach(ColorScheme.allCases, id: \.self) {
-            PullRequestCell(pullRequest: PullRequest(pullRequest: PrInfo(id: "1", isReadByViewer: false, url: "https://google.com", repository: .init(id: "2", nameWithOwner: "testUser/testRepo"), baseRefName: "main", headRefName: "dev", author: .makeBot(login: "testBot"), title: "Test PR title", body: "Test PR Body", changedFiles: 3, additions: 4, deletions: 5, commits: .init(nodes: [.init(id: "6")]), labels: .init(nodes: .none), state: .open, viewerLatestReview: nil, mergedAt: "2021", updatedAt: "2021"))).preferredColorScheme($0)
+            PullRequestCell(pullRequest: PullRequest(pullRequest: PrInfo(id: "1", isReadByViewer: false, url: "https://google.com", repository: .init(id: "2", nameWithOwner: "testUser/testRepo"), baseRefName: "main", headRefName: "dev", author: .makeBot(login: "testBot"), title: "Test PR title", body: "Test PR Body", changedFiles: 3, additions: 4, deletions: 5, commits: .init(nodes: [.init(id: "6")]), labels: .init(nodes: .none), state: .open, viewerLatestReview: nil, mergedAt: "2021", updatedAt: "2021"), currentUser: "test")).preferredColorScheme($0)
         }
     }
 }

--- a/PRChecker/macOS/Unique Views/MenuBarPRCell.swift
+++ b/PRChecker/macOS/Unique Views/MenuBarPRCell.swift
@@ -69,7 +69,7 @@ struct MenuBarPRCell: View {
 struct MenuBarPRCell_Previews: PreviewProvider {
     static var previews: some View {
         ForEach(ColorScheme.allCases, id: \.self) {
-            MenuBarPRCell(pullRequest: PullRequest(pullRequest: PrInfo(id: "1", isReadByViewer: false, url: "https://google.com", repository: .init(id: "2", nameWithOwner: "testUser/testRepo"), baseRefName: "main", headRefName: "dev", author: .makeBot(login: "testBot"), title: "Test PR title", body: "Test PR Body", changedFiles: 3, additions: 4, deletions: 5, commits: .init(nodes: [.init(id: "6")]), labels: .init(nodes: .none), state: .open, viewerLatestReview: nil, mergedAt: "2021", updatedAt: "2021"))).preferredColorScheme($0)
+            MenuBarPRCell(pullRequest: PullRequest(pullRequest: PrInfo(id: "1", isReadByViewer: false, url: "https://google.com", repository: .init(id: "2", nameWithOwner: "testUser/testRepo"), baseRefName: "main", headRefName: "dev", author: .makeBot(login: "testBot"), title: "Test PR title", body: "Test PR Body", changedFiles: 3, additions: 4, deletions: 5, commits: .init(nodes: [.init(id: "6")]), labels: .init(nodes: .none), state: .open, viewerLatestReview: nil, mergedAt: "2021", updatedAt: "2021"), currentUser: "test")).preferredColorScheme($0)
         }
     }
 }


### PR DESCRIPTION
The ID of each PR is certainly unique, but the same PR can be assigned to multiple people. SwiftUI doesn't like that and it will complain in Debug mode, but crash in archive/real mode.

In that case we need to find something to make it more unique. In this case, I've preserved the username we were searching for and combined it with the ID to make it section-unique.

It also will help prep for #26  as we will need the user information for that as well.

