### PR TITLE
Fix POV for Watched Users

### DIFF
--- a/PRChecker/Shared/General/PRItemType.swift
+++ b/PRChecker/Shared/General/PRItemType.swift
@@ -18,7 +18,7 @@ enum PRItemType {
     case commits
     case description
     case tag
-    case viewerStatus
+    case reviewStatus
     case readStatus
     case backwardArrow
 
@@ -41,7 +41,7 @@ enum PRItemType {
                 return "doc.text"
             case .tag:
                 return "tag"
-            case .viewerStatus:
+            case .reviewStatus:
                 return "bell.badge"
             case .readStatus:
                 return "envelope.open"

--- a/PRChecker/Shared/GraphQL/API.swift
+++ b/PRChecker/Shared/GraphQL/API.swift
@@ -922,10 +922,16 @@ public struct PrInfo: GraphQLFragment {
         }
       }
       state
-      viewerLatestReview {
+      reviews(last: 100) {
         __typename
-        id
-        state
+        nodes {
+          __typename
+          author {
+            __typename
+            login
+          }
+          state
+        }
       }
       mergedAt
       updatedAt
@@ -952,7 +958,7 @@ public struct PrInfo: GraphQLFragment {
       GraphQLField("commits", arguments: ["last": 100], type: .nonNull(.object(Commit.selections))),
       GraphQLField("labels", arguments: ["last": 10], type: .object(Label.selections)),
       GraphQLField("state", type: .nonNull(.scalar(PullRequestState.self))),
-      GraphQLField("viewerLatestReview", type: .object(ViewerLatestReview.selections)),
+      GraphQLField("reviews", arguments: ["last": 100], type: .object(Review.selections)),
       GraphQLField("mergedAt", type: .scalar(String.self)),
       GraphQLField("updatedAt", type: .nonNull(.scalar(String.self))),
     ]
@@ -964,8 +970,8 @@ public struct PrInfo: GraphQLFragment {
     self.resultMap = unsafeResultMap
   }
 
-  public init(id: GraphQLID, isReadByViewer: Bool? = nil, url: String, repository: Repository, baseRefName: String, headRefName: String, author: Author? = nil, title: String, body: String, changedFiles: Int, additions: Int, deletions: Int, commits: Commit, labels: Label? = nil, state: PullRequestState, viewerLatestReview: ViewerLatestReview? = nil, mergedAt: String? = nil, updatedAt: String) {
-    self.init(unsafeResultMap: ["__typename": "PullRequest", "id": id, "isReadByViewer": isReadByViewer, "url": url, "repository": repository.resultMap, "baseRefName": baseRefName, "headRefName": headRefName, "author": author.flatMap { (value: Author) -> ResultMap in value.resultMap }, "title": title, "body": body, "changedFiles": changedFiles, "additions": additions, "deletions": deletions, "commits": commits.resultMap, "labels": labels.flatMap { (value: Label) -> ResultMap in value.resultMap }, "state": state, "viewerLatestReview": viewerLatestReview.flatMap { (value: ViewerLatestReview) -> ResultMap in value.resultMap }, "mergedAt": mergedAt, "updatedAt": updatedAt])
+  public init(id: GraphQLID, isReadByViewer: Bool? = nil, url: String, repository: Repository, baseRefName: String, headRefName: String, author: Author? = nil, title: String, body: String, changedFiles: Int, additions: Int, deletions: Int, commits: Commit, labels: Label? = nil, state: PullRequestState, reviews: Review? = nil, mergedAt: String? = nil, updatedAt: String) {
+    self.init(unsafeResultMap: ["__typename": "PullRequest", "id": id, "isReadByViewer": isReadByViewer, "url": url, "repository": repository.resultMap, "baseRefName": baseRefName, "headRefName": headRefName, "author": author.flatMap { (value: Author) -> ResultMap in value.resultMap }, "title": title, "body": body, "changedFiles": changedFiles, "additions": additions, "deletions": deletions, "commits": commits.resultMap, "labels": labels.flatMap { (value: Label) -> ResultMap in value.resultMap }, "state": state, "reviews": reviews.flatMap { (value: Review) -> ResultMap in value.resultMap }, "mergedAt": mergedAt, "updatedAt": updatedAt])
   }
 
   public var __typename: String {
@@ -1126,13 +1132,13 @@ public struct PrInfo: GraphQLFragment {
     }
   }
 
-  /// The latest review given from the viewer.
-  public var viewerLatestReview: ViewerLatestReview? {
+  /// A list of reviews associated with the pull request.
+  public var reviews: Review? {
     get {
-      return (resultMap["viewerLatestReview"] as? ResultMap).flatMap { ViewerLatestReview(unsafeResultMap: $0) }
+      return (resultMap["reviews"] as? ResultMap).flatMap { Review(unsafeResultMap: $0) }
     }
     set {
-      resultMap.updateValue(newValue?.resultMap, forKey: "viewerLatestReview")
+      resultMap.updateValue(newValue?.resultMap, forKey: "reviews")
     }
   }
 
@@ -1442,14 +1448,13 @@ public struct PrInfo: GraphQLFragment {
     }
   }
 
-  public struct ViewerLatestReview: GraphQLSelectionSet {
-    public static let possibleTypes: [String] = ["PullRequestReview"]
+  public struct Review: GraphQLSelectionSet {
+    public static let possibleTypes: [String] = ["PullRequestReviewConnection"]
 
     public static var selections: [GraphQLSelection] {
       return [
         GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
-        GraphQLField("id", type: .nonNull(.scalar(GraphQLID.self))),
-        GraphQLField("state", type: .nonNull(.scalar(PullRequestReviewState.self))),
+        GraphQLField("nodes", type: .list(.object(Node.selections))),
       ]
     }
 
@@ -1459,8 +1464,8 @@ public struct PrInfo: GraphQLFragment {
       self.resultMap = unsafeResultMap
     }
 
-    public init(id: GraphQLID, state: PullRequestReviewState) {
-      self.init(unsafeResultMap: ["__typename": "PullRequestReview", "id": id, "state": state])
+    public init(nodes: [Node?]? = nil) {
+      self.init(unsafeResultMap: ["__typename": "PullRequestReviewConnection", "nodes": nodes.flatMap { (value: [Node?]) -> [ResultMap?] in value.map { (value: Node?) -> ResultMap? in value.flatMap { (value: Node) -> ResultMap in value.resultMap } } }])
     }
 
     public var __typename: String {
@@ -1472,22 +1477,120 @@ public struct PrInfo: GraphQLFragment {
       }
     }
 
-    public var id: GraphQLID {
+    /// A list of nodes.
+    public var nodes: [Node?]? {
       get {
-        return resultMap["id"]! as! GraphQLID
+        return (resultMap["nodes"] as? [ResultMap?]).flatMap { (value: [ResultMap?]) -> [Node?] in value.map { (value: ResultMap?) -> Node? in value.flatMap { (value: ResultMap) -> Node in Node(unsafeResultMap: value) } } }
       }
       set {
-        resultMap.updateValue(newValue, forKey: "id")
+        resultMap.updateValue(newValue.flatMap { (value: [Node?]) -> [ResultMap?] in value.map { (value: Node?) -> ResultMap? in value.flatMap { (value: Node) -> ResultMap in value.resultMap } } }, forKey: "nodes")
       }
     }
 
-    /// Identifies the current state of the pull request review.
-    public var state: PullRequestReviewState {
-      get {
-        return resultMap["state"]! as! PullRequestReviewState
+    public struct Node: GraphQLSelectionSet {
+      public static let possibleTypes: [String] = ["PullRequestReview"]
+
+      public static var selections: [GraphQLSelection] {
+        return [
+          GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+          GraphQLField("author", type: .object(Author.selections)),
+          GraphQLField("state", type: .nonNull(.scalar(PullRequestReviewState.self))),
+        ]
       }
-      set {
-        resultMap.updateValue(newValue, forKey: "state")
+
+      public private(set) var resultMap: ResultMap
+
+      public init(unsafeResultMap: ResultMap) {
+        self.resultMap = unsafeResultMap
+      }
+
+      public init(author: Author? = nil, state: PullRequestReviewState) {
+        self.init(unsafeResultMap: ["__typename": "PullRequestReview", "author": author.flatMap { (value: Author) -> ResultMap in value.resultMap }, "state": state])
+      }
+
+      public var __typename: String {
+        get {
+          return resultMap["__typename"]! as! String
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "__typename")
+        }
+      }
+
+      /// The actor who authored the comment.
+      public var author: Author? {
+        get {
+          return (resultMap["author"] as? ResultMap).flatMap { Author(unsafeResultMap: $0) }
+        }
+        set {
+          resultMap.updateValue(newValue?.resultMap, forKey: "author")
+        }
+      }
+
+      /// Identifies the current state of the pull request review.
+      public var state: PullRequestReviewState {
+        get {
+          return resultMap["state"]! as! PullRequestReviewState
+        }
+        set {
+          resultMap.updateValue(newValue, forKey: "state")
+        }
+      }
+
+      public struct Author: GraphQLSelectionSet {
+        public static let possibleTypes: [String] = ["Bot", "EnterpriseUserAccount", "Mannequin", "Organization", "User"]
+
+        public static var selections: [GraphQLSelection] {
+          return [
+            GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
+            GraphQLField("login", type: .nonNull(.scalar(String.self))),
+          ]
+        }
+
+        public private(set) var resultMap: ResultMap
+
+        public init(unsafeResultMap: ResultMap) {
+          self.resultMap = unsafeResultMap
+        }
+
+        public static func makeBot(login: String) -> Author {
+          return Author(unsafeResultMap: ["__typename": "Bot", "login": login])
+        }
+
+        public static func makeEnterpriseUserAccount(login: String) -> Author {
+          return Author(unsafeResultMap: ["__typename": "EnterpriseUserAccount", "login": login])
+        }
+
+        public static func makeMannequin(login: String) -> Author {
+          return Author(unsafeResultMap: ["__typename": "Mannequin", "login": login])
+        }
+
+        public static func makeOrganization(login: String) -> Author {
+          return Author(unsafeResultMap: ["__typename": "Organization", "login": login])
+        }
+
+        public static func makeUser(login: String) -> Author {
+          return Author(unsafeResultMap: ["__typename": "User", "login": login])
+        }
+
+        public var __typename: String {
+          get {
+            return resultMap["__typename"]! as! String
+          }
+          set {
+            resultMap.updateValue(newValue, forKey: "__typename")
+          }
+        }
+
+        /// The username of the actor.
+        public var login: String {
+          get {
+            return resultMap["login"]! as! String
+          }
+          set {
+            resultMap.updateValue(newValue, forKey: "login")
+          }
+        }
       }
     }
   }

--- a/PRChecker/Shared/GraphQL/NetworkService.swift
+++ b/PRChecker/Shared/GraphQL/NetworkService.swift
@@ -149,7 +149,7 @@ extension NetworkSerivce {
                     return
                 }
                 let resultList = prList.compactMap { $0 }
-                    .filter { $0.author?.login != SettingsViewModel.shared.loginViewModel.username }
+                    .filter { $0.author?.login.lowercased() != networkQuery.username.lowercased() }
                     .map {
                         PullRequest(pullRequest: $0, currentUser: networkQuery.username)
                     }
@@ -181,7 +181,7 @@ extension NetworkSerivce {
                     return
                 }
                 let resultList = prList.compactMap { $0 }
-                    .filter { $0.author?.login != SettingsViewModel.shared.loginViewModel.username }
+                    .filter { $0.author?.login.lowercased() != networkQuery.username.lowercased() }
                     .map {
                         OldPullRequest(pullRequest: $0, currentUser: networkQuery.username, viewingUser: SettingsViewModel.shared.loginViewModel.username)
                     }

--- a/PRChecker/Shared/GraphQL/Queries.graphql
+++ b/PRChecker/Shared/GraphQL/Queries.graphql
@@ -35,10 +35,15 @@ fragment PRInfo on PullRequest {
     }
 
     state
-    viewerLatestReview {
-        id
-        state
+    reviews(last: 100) {
+        nodes {
+            author {
+                login
+            }
+            state
+        }
     }
+    
     mergedAt
     updatedAt
 }

--- a/PRChecker/Shared/Models/AbstractPullRequest.swift
+++ b/PRChecker/Shared/Models/AbstractPullRequest.swift
@@ -26,7 +26,7 @@ enum PRState: String {
     }
 }
 
-enum ViewerStatus: String {
+enum ReviewStatus: String {
     case waiting = "Waiting"
     case commented = "Commented"
     case blocked = "Blocked"
@@ -96,7 +96,7 @@ struct ContentViewModel {
 }
 
 struct FooterViewModel {
-    let status: ViewerStatus
+    let status: ReviewStatus
     let updatedTime: String
 }
 
@@ -125,7 +125,7 @@ class AbstractPullRequest: ObservableObject, Identifiable {
     
     lazy var footerViewModel: FooterViewModel = {
         FooterViewModel(
-            status: viewerStatus,
+            status: reviewStatus,
             updatedTime: updatedAt
         )
     }()
@@ -168,7 +168,7 @@ class AbstractPullRequest: ObservableObject, Identifiable {
     
     var state: PRState { .closed }
     
-    var viewerStatus: ViewerStatus { .waiting }
+    var reviewStatus: ReviewStatus { .waiting }
     
     var mergedAt: String? { nil }
     

--- a/PRChecker/Shared/Models/OldPullRequest.swift
+++ b/PRChecker/Shared/Models/OldPullRequest.swift
@@ -88,12 +88,14 @@ class OldPullRequest: AbstractPullRequest {
         }
     }
     
-    override var viewerStatus: ViewerStatus {
+    override var reviewStatus: ReviewStatus {
         guard let nodes = pullRequest.reviews?.nodes else {
             return .waiting     // No reviews at all
         }
         
-        guard let viewersReview = nodes.last(where: { $0?.author?.login == viewingUser }) else {
+        guard
+            let viewersReview = nodes.last(where: { $0?.author?.login.lowercased() == currentUser.lowercased() })
+        else {
             return .waiting     // Viewer has not reviewed
         }
         

--- a/PRChecker/Shared/Models/PullRequest.swift
+++ b/PRChecker/Shared/Models/PullRequest.swift
@@ -86,8 +86,18 @@ class PullRequest: AbstractPullRequest {
         }
     }
     
-    override var viewerStatus: ViewerStatus {
-        switch pullRequest.viewerLatestReview?.state {
+    override var reviewStatus: ReviewStatus {
+        guard let nodes = pullRequest.reviews?.nodes else {
+            return .waiting     // No reviews at all
+        }
+        
+        guard
+            let viewersReview = nodes.last(where: { $0?.author?.login.lowercased() == currentUser.lowercased() })
+        else {
+            return .waiting     // Viewer has not reviewed
+        }
+        
+        switch viewersReview?.state {
         case .none, .pending, .dismissed:
             return .waiting
         case .approved:
@@ -97,7 +107,7 @@ class PullRequest: AbstractPullRequest {
         case .commented:
             return .commented
         default:
-            assertionFailure("Unknown status: \(String(describing: pullRequest.viewerLatestReview?.state))")
+            assertionFailure("Unknown status: \(String(describing: viewersReview?.state))")
             return .waiting
         }
     }

--- a/PRChecker/Shared/Unique Views/PullRequestCell.swift
+++ b/PRChecker/Shared/Unique Views/PullRequestCell.swift
@@ -186,9 +186,9 @@ private struct Footer: View {
                 Text(footer.updatedTime)
                     .padding(.horizontal, 8)
             } icon: {
-                PRItemType.viewerStatus.image
+                PRItemType.reviewStatus.image
             }
-            .labelStyle(PRItemLabel.Style(type: .viewerStatus))
+            .labelStyle(PRItemLabel.Style(type: .reviewStatus))
         }
     }
 }
@@ -196,7 +196,7 @@ private struct Footer: View {
 struct PullRequestCell_Previews: PreviewProvider {
     static var previews: some View {
         ForEach(ColorScheme.allCases, id: \.self) {
-            PullRequestCell(pullRequest: PullRequest(pullRequest: PrInfo(id: "1", isReadByViewer: false, url: "https://google.com", repository: .init(id: "2", nameWithOwner: "testUser/testRepo"), baseRefName: "main", headRefName: "dev", author: .makeBot(login: "testBot"), title: "Test PR title", body: "Test PR Body", changedFiles: 3, additions: 4, deletions: 5, commits: .init(nodes: [.init(id: "6")]), labels: .init(nodes: .none), state: .open, viewerLatestReview: nil, mergedAt: "2021", updatedAt: "2021"), currentUser: "test")).preferredColorScheme($0)
+            PullRequestCell(pullRequest: PullRequest(pullRequest: PrInfo(id: "1", isReadByViewer: false, url: "https://google.com", repository: .init(id: "2", nameWithOwner: "testUser/testRepo"), baseRefName: "main", headRefName: "dev", author: .makeBot(login: "testBot"), title: "Test PR title", body: "Test PR Body", changedFiles: 3, additions: 4, deletions: 5, commits: .init(nodes: [.init(id: "6")]), labels: .init(nodes: .none), state: .open, reviews: nil, mergedAt: "2021", updatedAt: "2021"), currentUser: "test")).preferredColorScheme($0)
         }
     }
 }

--- a/PRChecker/Shared/ViewModels/FilterViewModel.swift
+++ b/PRChecker/Shared/ViewModels/FilterViewModel.swift
@@ -23,12 +23,12 @@ class FilterViewModel: ObservableObject {
     static let reviewStatusFilter: FilterSection = {
         FilterSection(
             name: "Review Status",
-            type: .viewerStatus,
+            type: .reviewStatus,
             filters: [
-                Filter(name: "Waiting") { $0.viewerStatus == .waiting },
-                Filter(name: "Blocked") { $0.viewerStatus == .blocked },
-                Filter(name: "Commented") { $0.viewerStatus == .commented },
-                Filter(name: "Approved") { $0.viewerStatus == .approved },
+                Filter(name: "Waiting") { $0.reviewStatus == .waiting },
+                Filter(name: "Blocked") { $0.reviewStatus == .blocked },
+                Filter(name: "Commented") { $0.reviewStatus == .commented },
+                Filter(name: "Approved") { $0.reviewStatus == .approved },
             ]
         )
     }()

--- a/PRChecker/macOS/Unique Views/MenuBarPRCell.swift
+++ b/PRChecker/macOS/Unique Views/MenuBarPRCell.swift
@@ -18,14 +18,14 @@ struct MenuBarPRCell: View {
             // Viewer Status
             Label {
                 TagView(
-                    text: pullRequest.viewerStatus.rawValue,
+                    text: pullRequest.reviewStatus.rawValue,
                     foregroundColor: .white,
-                    backgroundColor: pullRequest.viewerStatus.color
+                    backgroundColor: pullRequest.reviewStatus.color
                 )
                 Spacer()
                 Text(pullRequest.updatedAt)
             } icon: {
-                PRItemType.viewerStatus.image
+                PRItemType.reviewStatus.image
             }
 
             Divider()
@@ -69,7 +69,7 @@ struct MenuBarPRCell: View {
 struct MenuBarPRCell_Previews: PreviewProvider {
     static var previews: some View {
         ForEach(ColorScheme.allCases, id: \.self) {
-            MenuBarPRCell(pullRequest: PullRequest(pullRequest: PrInfo(id: "1", isReadByViewer: false, url: "https://google.com", repository: .init(id: "2", nameWithOwner: "testUser/testRepo"), baseRefName: "main", headRefName: "dev", author: .makeBot(login: "testBot"), title: "Test PR title", body: "Test PR Body", changedFiles: 3, additions: 4, deletions: 5, commits: .init(nodes: [.init(id: "6")]), labels: .init(nodes: .none), state: .open, viewerLatestReview: nil, mergedAt: "2021", updatedAt: "2021"), currentUser: "test")).preferredColorScheme($0)
+            MenuBarPRCell(pullRequest: PullRequest(pullRequest: PrInfo(id: "1", isReadByViewer: false, url: "https://google.com", repository: .init(id: "2", nameWithOwner: "testUser/testRepo"), baseRefName: "main", headRefName: "dev", author: .makeBot(login: "testBot"), title: "Test PR title", body: "Test PR Body", changedFiles: 3, additions: 4, deletions: 5, commits: .init(nodes: [.init(id: "6")]), labels: .init(nodes: .none), state: .open, reviews: nil, mergedAt: "2021", updatedAt: "2021"), currentUser: "test")).preferredColorScheme($0)
         }
     }
 }


### PR DESCRIPTION
Addresses #26.

Included a new property in the PullResuests so that we can compare the reviews for a particular person, in this case the same as the query. If functions similarly to how `OldPullRequest`s functioned up until now. Since this requires a new GraphQL query, the `API.swift` file has some newly generated changes.

In addition, I changed the naming and added a fake "isRead" to the `OldPullRequest` by checking if the `currentUser` has made any comments yet.