### PR TITLE
[UI] Make Drop UI more like normal macOS app

### DIFF
--- a/PRChecker/Shared/PRCheckerApp.swift
+++ b/PRChecker/Shared/PRCheckerApp.swift
@@ -19,7 +19,7 @@ struct PRCheckerApp: App {
             ContentView()
                 .environmentObject(FilterViewModel())
                 .background(Color.gray6)
-                .frame(minWidth: 1280, minHeight: 768)
+                .frame(minWidth: 960, minHeight: 640)
         }.commands {
             SidebarCommands()
         }

--- a/PRChecker/Shared/PRCheckerApp.swift
+++ b/PRChecker/Shared/PRCheckerApp.swift
@@ -19,7 +19,9 @@ struct PRCheckerApp: App {
             ContentView()
                 .environmentObject(FilterViewModel())
                 .background(Color.gray6)
-                .frame(minWidth: 655, minHeight: 375)
+                .frame(minWidth: 1280, minHeight: 768)
+        }.commands {
+            SidebarCommands()
         }
     }
 }

--- a/PRChecker/Shared/Unique Views/ContentView.swift
+++ b/PRChecker/Shared/Unique Views/ContentView.swift
@@ -44,7 +44,7 @@ struct ContentView: View {
                         .renderingMode(.template)
                         .foregroundColor(Color.primary)
                 }
-                .popover(isPresented: $showSettings, arrowEdge: .bottom) {
+                .popover(isPresented: $showSettings) {
                     SettingsView()
                         .frame(minWidth: 200, maxHeight: 800, alignment: .leading)
                         .onDisappear { prListViewModel.getPRList() }

--- a/PRChecker/Shared/Unique Views/ContentView.swift
+++ b/PRChecker/Shared/Unique Views/ContentView.swift
@@ -13,46 +13,60 @@ struct ContentView: View {
     var prListViewModel = PRListViewModel()
     
     var body: some View {
-        GeometryReader { geometry in
-            HStack {
-                Divider()
-                    .background(Color.gray5)
+        NavigationView {
+            // Side bar
+            FilterView()
+                .frame(minWidth: 300)
+            // PR List
+            GeometryReader { geometry in
                 PRListView(prListViewModel: prListViewModel)
-                    .frame(minWidth: 300, maxWidth: max(geometry.size.width, 300), minHeight: geometry.size.height, alignment: .topLeading)
-                Divider()
-                    .background(Color.gray5)
-                FilterView()
-                    .frame(width: 300, height: geometry.size.height)
+                    .frame(
+                        minWidth: 300,
+                        maxWidth: max(geometry.size.width, 300),
+                        minHeight: geometry.size.height,
+                        alignment: .topLeading
+                    )
             }
-            .frame(width: geometry.size.width, height: geometry.size.height)
-        }
-        .overlay(
-            HStack {
-                VStack {
-                    Spacer()
+            .overlay(
+                HStack {
+                    VStack {
+                        Spacer()
+                        
+                        Button {
+                            showSettings.toggle()
+                        } label: {
+                            Text(.init(systemName: "gearshape"))
+                                .font(.system(size: 45))
+                                .fontWeight(.thin)
+                                .foregroundColor(.secondary)
+                        }
+                        .buttonStyle(LinkButtonStyle())
+                        .popover(isPresented: $showSettings, arrowEdge: .bottom) {
+                            SettingsView()
+                                .frame(minWidth: 200, maxHeight: 800, alignment: .leading)
+                                .onDisappear { prListViewModel.getPRList() }
+                        }
+                        .padding(8)
+                        .background(Color.gray4.clipShape(Circle()))
+                    }
+                    .padding([.leading, .bottom])
                     
-                    Button {
-                        showSettings.toggle()
-                    } label: {
-                        Text(.init(systemName: "gearshape"))
-                            .font(.system(size: 45))
-                            .fontWeight(.thin)
-                            .foregroundColor(.secondary)
-                    }
-                    .buttonStyle(LinkButtonStyle())
-                    .popover(isPresented: $showSettings, arrowEdge: .bottom) {
-                        SettingsView()
-                            .frame(minWidth: 200, maxHeight: 800, alignment: .leading)
-                            .onDisappear { prListViewModel.getPRList() }
-                    }
-                    .padding(8)
-                    .background(Color.gray4.clipShape(Circle()))
+                    Spacer()
                 }
-                .padding([.leading, .bottom])
-                
-                Spacer()
+            )
+        }.toolbar {
+            ToolbarItem(placement: .navigation) {
+                Button(action: toggleSidebar, label: {
+                    Image(systemName: "sidebar.leading")
+                })
             }
-        )
+        }
+    }
+    
+    private func toggleSidebar() {
+        #if canImport(AppKit)
+        NSApp.keyWindow?.firstResponder?.tryToPerform(#selector(NSSplitViewController.toggleSidebar(_:)), with: nil)
+        #endif
     }
 }
 

--- a/PRChecker/Shared/Unique Views/ContentView.swift
+++ b/PRChecker/Shared/Unique Views/ContentView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct ContentView: View {
     @State var showLogin = !SettingsViewModel.shared.loginViewModel.canLogin
     @State var showSettings = false
+    
     var prListViewModel = PRListViewModel()
     
     var body: some View {
@@ -27,45 +28,37 @@ struct ContentView: View {
                         alignment: .topLeading
                     )
             }
-            .overlay(
-                HStack {
-                    VStack {
-                        Spacer()
-                        
-                        Button {
-                            showSettings.toggle()
-                        } label: {
-                            Text(.init(systemName: "gearshape"))
-                                .font(.system(size: 45))
-                                .fontWeight(.thin)
-                                .foregroundColor(.secondary)
-                        }
-                        .buttonStyle(LinkButtonStyle())
-                        .popover(isPresented: $showSettings, arrowEdge: .bottom) {
-                            SettingsView()
-                                .frame(minWidth: 200, maxHeight: 800, alignment: .leading)
-                                .onDisappear { prListViewModel.getPRList() }
-                        }
-                        .padding(8)
-                        .background(Color.gray4.clipShape(Circle()))
-                    }
-                    .padding([.leading, .bottom])
-                    
-                    Spacer()
-                }
-            )
         }.toolbar {
             ToolbarItem(placement: .navigation) {
                 Button(action: toggleSidebar, label: {
                     Image(systemName: "sidebar.leading")
+                        .renderingMode(.template)
+                        .foregroundColor(Color.primary)
                 })
+            }
+            ToolbarItem(placement: .primaryAction) {
+                Button{
+                    showSettings.toggle()
+                } label: {
+                    Image(systemName: "gearshape")
+                        .renderingMode(.template)
+                        .foregroundColor(Color.primary)
+                }
+                .popover(isPresented: $showSettings, arrowEdge: .bottom) {
+                    SettingsView()
+                        .frame(minWidth: 200, maxHeight: 800, alignment: .leading)
+                        .onDisappear { prListViewModel.getPRList() }
+                }
             }
         }
     }
     
     private func toggleSidebar() {
         #if canImport(AppKit)
-        NSApp.keyWindow?.firstResponder?.tryToPerform(#selector(NSSplitViewController.toggleSidebar(_:)), with: nil)
+        NSApp.keyWindow?.firstResponder?.tryToPerform(
+            #selector(NSSplitViewController.toggleSidebar(_:)),
+            with: nil
+        )
         #endif
     }
 }

--- a/PRChecker/Shared/Unique Views/FilterView.swift
+++ b/PRChecker/Shared/Unique Views/FilterView.swift
@@ -11,11 +11,11 @@ struct FilterView: View {
     var body: some View {
         VStack {
             Header()
-                .padding(EdgeInsets(top: 16, leading: 0, bottom: 8, trailing: 8))
+                .padding(.horizontal, 8)
             Divider()
                 .background(Color.gray5)
             FilterContentView()
-                .padding(.leading, 8)
+                .padding(EdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12))
             Spacer()
         }
     }
@@ -31,19 +31,19 @@ private struct Header: View {
                 Text("Filter by")
                     .fontWeight(.bold)
             } icon: {
-                Image(systemName: "line.horizontal.3.decrease")
+                Image(systemName: "line.3.horizontal.decrease")
                     .scaledToFit()
             }
             .font(.title)
             Spacer()
-            Button("Reset Filters") {
+            Button("Reset") {
                 filterViewModel.sections.map(\.filters).flatMap { $0 }.forEach {
                     $0.isEnabled = false
                 }
                 filterViewModel.sections.forEach { $0.updateFilters() }
                 filterViewModel.updateFilters()
             }
-            .font(.title2)
+            .font(.title3)
             .foregroundColor(.blue)
             .buttonStyle(PlainButtonStyle())
         }

--- a/PRChecker/Shared/Unique Views/FilterView.swift
+++ b/PRChecker/Shared/Unique Views/FilterView.swift
@@ -15,7 +15,7 @@ struct FilterView: View {
             Divider()
                 .background(Color.gray5)
             FilterContentView()
-                .padding(EdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 12))
+                .padding(EdgeInsets(top: 8, leading: 12, bottom: 8, trailing: 0))
             Spacer()
         }
     }

--- a/PRChecker/Shared/Unique Views/PRListView.swift
+++ b/PRChecker/Shared/Unique Views/PRListView.swift
@@ -19,7 +19,7 @@ struct PRListView: View {
                 completion()
             }
         }) {
-            LazyVGrid(columns: [GridItem(.adaptive(minimum: 300))], alignment: .leading, pinnedViews: [.sectionHeaders]) {
+            LazyVGrid(columns: [GridItem(.adaptive(minimum: 300), alignment: .top)], alignment: .leading, pinnedViews: [.sectionHeaders]) {
                 
                 if let filteredPRList = myPRManager.prList.filter(filterViewModel.combinedFilter?.filter ?? { _ in true }), !filteredPRList.isEmpty {
                     PRSectionView(name: "You", prList: filteredPRList)
@@ -30,7 +30,6 @@ struct PRListView: View {
                     if let filteredPRList = networkPR.pullRequests.filter(filterViewModel.combinedFilter?.filter ?? { _ in true }), !filteredPRList.isEmpty {
                         PRSectionView(name: networkPR.name, prList: filteredPRList)
                     }
-                    
                 }
             }
             .padding()


### PR DESCRIPTION
## Description
- Moved filter view to side bar
- Moved the setting icon to tool bar (I also like the previous settings button, I can revert this change if current one doesn't make sense)
- Placed the PR cell at the top of each row

<img width="1320" alt="Screen Shot 2021-11-25 at 20 52 01" src="https://user-images.githubusercontent.com/1570400/143438082-5e1fc048-0781-445f-8621-68f3944452ac.png">


